### PR TITLE
feat(Shipment): Few enhancements

### DIFF
--- a/shipment/shipment/doctype/shipment/shipment.js
+++ b/shipment/shipment/doctype/shipment/shipment.js
@@ -2,7 +2,407 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Shipment', {
-	// refresh: function(frm) {
+	address_query: function(frm, link_doctype, link_name, is_your_company_address) {
+		return {
+			query: 'frappe.contacts.doctype.address.address.address_query',
+			filters: {
+				link_doctype: link_doctype,
+				link_name: link_name,
+				is_your_company_address: is_your_company_address
+			}
+		}
+	},
+	contact_query: function(frm, link_doctype, link_name) {
+		return {
+			query: 'frappe.contacts.doctype.contact.contact.contact_query',
+			filters: {
+				link_doctype: link_doctype,
+				link_name: link_name
+			}
+		}
+	},
+	onload: function(frm) {
+		frm.set_query("delivery_address_name", () => {
+			let link_doctype = ''
+			let link_name = ''
+			let is_your_company_address = 0
+			if (frm.doc.delivery_to_type == 'Customer') {
+				link_doctype = 'Customer'
+				link_name = frm.doc.delivery_customer
+			}
+			if (frm.doc.delivery_to_type == 'Supplier') {
+				link_doctype = 'Supplier'
+				link_name = frm.doc.delivery_supplier
+			}
+			if (frm.doc.delivery_to_type == 'Company') {
+				link_doctype = 'Company'
+				link_name = frm.doc.delivery_company
+				is_your_company_address = 1
+			}
+			return frm.events.address_query(frm, link_doctype, link_name, is_your_company_address);
+		});
+		frm.set_query("pickup_address_name", () => {
+			let link_doctype = ''
+			let link_name = ''
+			let is_your_company_address = 0
+			if (frm.doc.pickup_from_type == 'Customer') {
+				link_doctype = 'Customer'
+				link_name = frm.doc.pickup_customer
+			}
+			if (frm.doc.pickup_from_type == 'Supplier') {
+				link_doctype = 'Supplier'
+				link_name = frm.doc.pickup_supplier
+			}
+			if (frm.doc.pickup_from_type == 'Company') {
+				link_doctype = 'Company'
+				link_name = frm.doc.pickup_company
+				is_your_company_address = 1
+			}
+			return frm.events.address_query(frm, link_doctype, link_name, is_your_company_address);
+		});
+		frm.set_query("delivery_contact_name", () => {
+			let link_doctype = ''
+			let link_name = ''
+			if (frm.doc.delivery_to_type == 'Customer') {
+				link_doctype = 'Customer'
+				link_name = frm.doc.delivery_customer
+			}
+			if (frm.doc.delivery_to_type == 'Supplier') {
+				link_doctype = 'Supplier'
+				link_name = frm.doc.delivery_supplier
+			}
+			if (frm.doc.delivery_to_type == 'Company') {
+				link_doctype = 'Company'
+				link_name = frm.doc.delivery_company
+			}
+			return frm.events.contact_query(frm, link_doctype, link_name);
+		});
+		frm.set_query("pickup_contact_name", () => {
+			let link_doctype = ''
+			let link_name = ''
+			if (frm.doc.pickup_from_type == 'Customer') {
+				link_doctype = 'Customer'
+				link_name = frm.doc.pickup_customer
+			}
+			if (frm.doc.pickup_from_type == 'Supplier') {
+				link_doctype = 'Supplier'
+				link_name = frm.doc.pickup_supplier
+			}
+			if (frm.doc.pickup_from_type == 'Company') {
+				link_doctype = 'Company'
+				link_name = frm.doc.pickup_company
+			}
+			return frm.events.contact_query(frm, link_doctype, link_name);
+		});
+		frm.set_query("delivery_note", "shipment_delivery_notes", function(doc, cdt, cdn) {
+			let row = locals[cdt][cdn]
+			if (frm.doc.delivery_to_type == "Customer") {
+				return {
+					filters: {
+						customer: frm.doc.delivery_customer,
+						docstatus: 0,
+						status: ["not in", ["Closed", "Completed"]]
+					}
+				};
+			}
+		})
+	},
+	refresh: function(frm) {
+		frm.set_value("pickup_date", frappe.datetime.add_days(frappe.datetime.get_today(), 1));
+		if (frm.doc.delivery_from_type != 'Company') {
+			frm.set_df_property("delivery_contact_name", "reqd", 1);
+		}
+		if (frm.doc.pickup_from_type != 'Company') {
+			frm.set_df_property("pickup_contact_name", "reqd", 1);
+		}
+	},
+	set_pickup_company_address: function(frm) {
+        frappe.db.get_value('Address', {
+			address_title: frm.doc.pickup_company, is_your_company_address: 1}, 'name', (r) => {
+				frm.set_value("pickup_address_name", r.name);
+        });
+	},
+	set_delivery_company_address: function(frm) {
+        frappe.db.get_value('Address', {
+			address_title: frm.doc.delivery_company, is_your_company_address: 1}, 'name', (r) => {
+				frm.set_value("delivery_address_name", r.name);
+        });
+	},
+	pickup_from_type: function(frm) {
+		if (frm.doc.pickup_from_type == 'Company') {
+			frm.set_value("pickup_company", frappe.defaults.get_default('company'));
+			frm.trigger('set_pickup_company_address');
+			frm.events.set_company_contact(frm, 'Pickup')
+			frm.set_df_property("pickup_contact_name", "reqd", 0);
+			frm.set_value("pickup_customer", '');
+			frm.set_value("pickup_supplier", '');
+		}
+		else {
+			frm.set_df_property("pickup_contact_name", "reqd", 1);
+			frm.trigger('clear_pickup_fields')
+		}
+		if (frm.doc.pickup_from_type == 'Customer') {
+			frm.set_value("pickup_company", '');
+			frm.set_value("pickup_supplier", '');
+		}
+		if (frm.doc.pickup_from_type == 'Supplier') {
+			frm.set_value("pickup_customer", '');
+			frm.set_value("pickup_company", '');
+		}
+	},
+	delivery_to_type: function(frm) {
+		if (frm.doc.delivery_to_type == 'Company') {
+			frm.set_value("delivery_company", frappe.defaults.get_default('company'));
+			frm.trigger('set_delivery_company_address');
+			frm.events.set_company_contact(frm, 'Delivery')
+			frm.set_df_property("delivery_contact_name", "reqd", 0);
+			frm.set_value("delivery_customer", '');
+			frm.set_value("delivery_supplier", '');
+			
+		}
+		else {
+			frm.set_df_property("delivery_contact_name", "reqd", 1);
+			frm.trigger('clear_delivery_fields')
+		}
+		if (frm.doc.delivery_to_type == 'Customer') {
+			frm.set_value("delivery_company", '');
+			frm.set_value("delivery_supplier", '');
+		}
+		if (frm.doc.delivery_to_type == 'Supplier') {
+			frm.set_value("delivery_customer", '');
+			frm.set_value("delivery_company", '');
+		}
+	},
+	delivery_supplier: function(frm) {
+		frm.trigger('clear_delivery_fields')
+	},
+	pickup_supplier: function(frm) {
+		frm.trigger('clear_pickup_fields')
+	},
+	delivery_customer: function(frm) {
+		frm.trigger('clear_delivery_fields')
+	},
+	pickup_customer: function(frm) {
+		frm.trigger('clear_pickup_fields')
+	},
+	delivery_address_name: function(frm) {
+		if (frm.doc.delivery_to_type == 'Company') {
+			erpnext.utils.get_address_display(frm, 'delivery_address_name', 'delivery_address', true);
+		}
+		else {
+			erpnext.utils.get_address_display(frm, 'delivery_address_name', 'delivery_address', false);
+		}
+	},
+	pickup_address_name: function(frm) {
+		if (frm.doc.pickup_from_type == 'Company') {
+			erpnext.utils.get_address_display(frm, 'pickup_address_name', 'pickup_address', true);
+		}
+		else {
+			erpnext.utils.get_address_display(frm, 'pickup_address_name', 'pickup_address', false);
+		}
+	},
+	get_contact_display: function(frm, contact_name, contact_type) {
+		frappe.call({
+			method: "frappe.contacts.doctype.contact.contact.get_contact_details",
+			args: { contact: contact_name },
+			callback: function(r) {
+				if(r.message) {
+					let contact_display = r.message.contact_display
+					if (r.message.contact_email) {
+						contact_display += '<br>' + r.message.contact_email
+					}
+					if (r.message.contact_mobile) {
+						contact_display += '<br>' + r.message.contact_mobile
+					}
+					if (r.message.contact_phone) {
+						contact_display += '<br>' + r.message.contact_phone
+					}
+					if (contact_type == 'Delivery'){
+						frm.set_value('delivery_contact', contact_display)
+					}
+					else {
+						frm.set_value('pickup_contact', contact_display)
+					}
+				}
+			}
+		})
+	},
+	delivery_contact_name: function(frm) {
+		if (frm.doc.delivery_contact_name) {
+			frm.events.get_contact_display(frm, frm.doc.delivery_contact_name, 'Delivery')
+		}
+	},
+	pickup_contact_name: function(frm) {
+		if (frm.doc.pickup_contact_name) {
+			frm.events.get_contact_display(frm, frm.doc.pickup_contact_name, 'Pickup')
+		}
+	},
+	set_company_contact: function(frm, delivery_type) {
+        frappe.db.get_value('User', {name: frappe.session.user}, ['full_name', 'email', 'phone'], (r) => {
+			let contact_display = r.full_name
+			if (r.email) {
+				contact_display += '<br>' + r.email
+			}
+			if (r.phone) {
+				contact_display += '<br>' + r.phone
+			}
+			if (delivery_type == 'Delivery') {
+				frm.set_value('delivery_contact', contact_display)
+			}
+			else {
+				frm.set_value('pickup_contact', contact_display)
+			}
+        });
+	},
+	pickup_company: function(frm) {
+		if (frm.doc.pickup_from_type == 'Company') {
+	        frm.trigger('set_pickup_company_address')
+	        frm.events.set_company_contact(frm, 'Pickup')
+		}
+	},
+	delivery_company: function(frm) {
+		if (frm.doc.delivery_to_type == 'Company') {
+	        frm.trigger('set_delivery_company_address')
+	        frm.events.set_company_contact(frm, 'Delivery')
+		}
+	},
+	delivery_customer: function(frm) {
+		frm.events.set_address_name(frm,'Customer',frm.doc.delivery_customer, 'Delivery')
+		frm.events.set_contact_name(frm,'Customer',frm.doc.delivery_customer, 'Delivery')
+	},
+	delivery_supplier: function(frm) {
+		frm.events.set_address_name(frm,'Supplier',frm.doc.delivery_supplier, 'Delivery')
+		frm.events.set_contact_name(frm,'Supplier',frm.doc.delivery_supplier, 'Delivery')
+	},
+	pickup_customer: function(frm) {
+		frm.events.set_address_name(frm,'Customer',frm.doc.pickup_customer, 'Pickup')
+		frm.events.set_contact_name(frm,'Customer',frm.doc.pickup_customer, 'Pickup')
+	},
+	pickup_supplier: function(frm) {
+		frm.events.set_address_name(frm,'Supplier',frm.doc.pickup_supplier, 'Pickup')
+		frm.events.set_contact_name(frm,'Supplier',frm.doc.pickup_supplier, 'Pickup')
+	},
+	set_address_name: function(frm, ref_doctype, ref_docname, delivery_type) {
+		frappe.call({
+			method: "shipment.shipment.doctype.shipment.shipment.get_address",
+			args: {
+				ref_doctype: ref_doctype,
+				docname: ref_docname
+			},
+			callback: function(r) {
+				if(r.message) {
+					if (delivery_type == 'Delivery') {
+						frm.set_value('delivery_address_name', r.message)
+					}
+					else {
+						frm.set_value('pickup_address_name', r.message)
+					}
+				}
+			}
+		})
+	},
+	set_contact_name: function(frm, ref_doctype, ref_docname, delivery_type) {
+		frappe.call({
+			method: "shipment.shipment.doctype.shipment.shipment.get_contact",
+			args: {
+				ref_doctype: ref_doctype,
+				docname: ref_docname
+			},
+			callback: function(r) {
+				if(r.message) {
+					if (delivery_type == 'Delivery') {
+						frm.set_value('delivery_contact_name', r.message)
+					}
+					else {
+						frm.set_value('pickup_contact_name', r.message)
+					}
+				}
+			}
+		})
+	},
+	add_preset: function(frm) {
+		if (frm.doc.preset) {
+			frappe.model.with_doc("Shipment Parcel Preset", frm.doc.preset, () => {
+				let parcel_preset = frappe.model.get_doc("Shipment Parcel Preset", frm.doc.preset);
+				let row = frappe.model.add_child(frm.doc, "Shipment Parcel", "shipment_parcel");
+				row.length = parcel_preset.length
+				row.width = parcel_preset.width
+				row.height = parcel_preset.height
+				frm.refresh_fields("shipment_parcel")
+			});
+		}
+	},
+	pickup_date: function(frm) {
+		if (frm.doc.pickup_date < frappe.datetime.get_today()) {
+			frappe.throw(__("Pickup Date cannot be in the past"));
+		}
+		if (frm.doc.pickup_date == frappe.datetime.get_today()) {
+			var pickup_time = frm.events.get_pickup_time(frm);
+			frm.set_value("pickup_from", pickup_time);
+			frm.trigger('set_pickup_to_time')
+		}	
+	},
+	pickup_from: function(frm) {
+		var pickup_time = frm.events.get_pickup_time(frm) 
+		if (frm.doc.pickup_from && frm.doc.pickup_date == frappe.datetime.get_today()) {
+			let current_hour = pickup_time.split(':')[0]
+			let current_min = pickup_time.split(':')[1]
+			let pickup_hour = frm.doc.pickup_from.split(':')[0]
+			let pickup_min = frm.doc.pickup_from.split(':')[1]
+			if (pickup_hour < current_hour || (pickup_hour == current_hour && pickup_min < current_min)) {
+				frm.set_value("pickup_from", pickup_time);
+				frappe.throw(__("Pickup Time cannot be in the past"));
+			}
+		}
+		frm.trigger('set_pickup_to_time')
+	},
+	get_pickup_time: function(frm) {
+		let current_hour = new Date().getHours()
+		let current_min = new Date().toLocaleString('en-US', {minute: 'numeric'})
+		if (current_min < 30) {
+			current_min = '30'
+		}
+		else {
+			current_min = '00'
+			current_hour = Number(current_hour)+1
+		}
+		if (Number(current_hour) > 19 || Number(current_hour) == 19){
+			frappe.throw(__("Today's pickup time is over, please select different date"));
+		}
+		current_hour = (current_hour < 10) ? '0' + current_hour : current_hour;
+		let pickup_time = current_hour +':'+ current_min
+		return pickup_time;
+	},
+	set_pickup_to_time: function(frm) {
+		let pickup_to_hour = Number(frm.doc.pickup_from.split(':')[0])+5
+		if (Number(pickup_to_hour) > 19 || Number(pickup_to_hour) == 19){
+			pickup_to_hour = 19
+		}
+		let pickup_to_min = frm.doc.pickup_from.split(':')[1]
+		let pickup_to = pickup_to_hour +':'+ pickup_to_min
+		frm.set_value("pickup_to", pickup_to);
+	},
+	clear_pickup_fields: function(frm) {
+		frm.set_value("pickup_address_name", '');
+		frm.set_value("pickup_contact_name", '');
+		frm.set_value("pickup_address", '');
+		frm.set_value("pickup_contact", '');
+	},
+	clear_delivery_fields: function(frm) {
+		frm.set_value("delivery_address_name", '');
+		frm.set_value("delivery_contact_name", '');
+		frm.set_value("delivery_address", '');
+		frm.set_value("delivery_contact", '');
+	},
+});
 
-	// }
+frappe.ui.form.on('Shipment Delivery Notes', {
+	grand_total: function(frm, cdt, cdn) {
+		let row = locals[cdt][cdn];
+		if (row.grand_total) {
+			var value_of_goods = parseFloat(frm.doc.value_of_goods)+parseFloat(row.grand_total)
+			frm.set_value("value_of_goods", value_of_goods);
+			frm.refresh_fields("value_of_goods")
+		}
+	},
 });

--- a/shipment/shipment/doctype/shipment/shipment.json
+++ b/shipment/shipment/doctype/shipment/shipment.json
@@ -1,5 +1,4 @@
 {
- "actions": [],
  "autoname": "####",
  "creation": "2020-03-27 19:04:24.455067",
  "doctype": "DocType",
@@ -11,10 +10,10 @@
   "pickup_company",
   "pickup_customer",
   "pickup_supplier",
+  "pickup_address_name",
   "pickup_address",
-  "pickup_from_address_html",
+  "pickup_contact_name",
   "pickup_contact",
-  "pickup_from_contact_html",
   "pickup_from_send_shipping_notification",
   "pickup_from_subscribe_to_status_updates",
   "column_break_2",
@@ -23,17 +22,17 @@
   "delivery_company",
   "delivery_customer",
   "delivery_supplier",
+  "delivery_address_name",
   "delivery_address",
-  "delivery_address_html",
+  "delivery_contact_name",
   "delivery_contact",
-  "delivery_to_contact",
   "delivery_to_send_shipping_notification",
   "delivery_to_subscribe_to_status_updates",
   "notification_details_section",
   "shipment_notification_subscriptions",
   "column_break_26",
   "shipment_status_update_subscriptions",
-  "pacels_section",
+  "parcels_section",
   "shipment_parcel",
   "preset",
   "add_preset",
@@ -105,21 +104,6 @@
    "options": "Supplier"
   },
   {
-   "fieldname": "pickup_address",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Address",
-   "options": "Address",
-   "reqd": 1
-  },
-  {
-   "fieldname": "pickup_contact",
-   "fieldtype": "Link",
-   "label": "Contact",
-   "options": "Contact",
-   "reqd": 1
-  },
-  {
    "default": "Customer",
    "fieldname": "delivery_to_type",
    "fieldtype": "Select",
@@ -149,17 +133,16 @@
   },
   {
    "fieldname": "delivery_address",
-   "fieldtype": "Link",
+   "fieldtype": "Small Text",
    "label": "Address",
-   "options": "Address",
-   "reqd": 1
+   "read_only": 1
   },
   {
+   "depends_on": "eval:doc.delivery_contact_name",
    "fieldname": "delivery_contact",
-   "fieldtype": "Data",
+   "fieldtype": "Small Text",
    "label": "Contact",
-   "options": "Contact",
-   "reqd": 1
+   "read_only": 1
   },
   {
    "fieldname": "shipment_details_section",
@@ -185,6 +168,7 @@
    "options": "Goods\nDocuments"
   },
   {
+   "default": "0",
    "fieldname": "value_of_goods",
    "fieldtype": "Currency",
    "label": "Value of Goods",
@@ -215,11 +199,6 @@
    "fieldtype": "Select",
    "label": "Pickup to",
    "options": "09:00\n09:30\n10:00\n10:30\n11:00\n11:30\n12:00\n12:30\n13:00\n13:30\n14:00\n14:30\n15:00\n15:30\n16:00\n16:30\n17:00\n17:30\n18:00\n18:30\n19:00"
-  },
-  {
-   "fieldname": "pacels_section",
-   "fieldtype": "Section Break",
-   "label": "Pacels"
   },
   {
    "fieldname": "shipment_parcel",
@@ -258,27 +237,6 @@
    "fieldtype": "Select",
    "label": "Pickup type",
    "options": "Pickup\nSelf delivery"
-  },
-  {
-   "fieldname": "pickup_from_address_html",
-   "fieldtype": "HTML",
-   "options": "content<br>content"
-  },
-  {
-   "fieldname": "pickup_from_contact_html",
-   "fieldtype": "HTML",
-   "options": "content<br>content",
-   "read_only": 1
-  },
-  {
-   "fieldname": "delivery_address_html",
-   "fieldtype": "HTML",
-   "options": "content<br>content"
-  },
-  {
-   "fieldname": "delivery_to_contact",
-   "fieldtype": "HTML",
-   "options": "content<br>content"
   },
   {
    "default": "0",
@@ -325,13 +283,56 @@
    "fieldtype": "Table",
    "label": "Shipment Status Update Subscriptions",
    "options": "Shipment Status Update Subscriptions"
+  },
+  {
+   "fieldname": "pickup_address_name",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Address",
+   "options": "Address",
+   "reqd": 1
+  },
+  {
+   "fieldname": "pickup_contact_name",
+   "fieldtype": "Link",
+   "label": "Contact",
+   "options": "Contact"
+  },
+  {
+   "fieldname": "delivery_address_name",
+   "fieldtype": "Link",
+   "label": "Address",
+   "options": "Address",
+   "reqd": 1
+  },
+  {
+   "fieldname": "delivery_contact_name",
+   "fieldtype": "Link",
+   "label": "Contact",
+   "options": "Contact"
+  },
+  {
+   "fieldname": "pickup_address",
+   "fieldtype": "Small Text",
+   "label": "Address",
+   "read_only": 1
+  },
+  {
+   "fieldname": "pickup_contact",
+   "fieldtype": "Small Text",
+   "label": "Contact",
+   "read_only": 1
+  },
+  {
+   "fieldname": "parcels_section",
+   "fieldtype": "Section Break",
+   "label": "Parcels"
   }
  ],
  "hide_toolbar": 1,
  "icon": "octicon-package",
  "is_submittable": 1,
- "links": [],
- "modified": "2020-03-28 09:21:42.246972",
+ "modified": "2020-03-28 19:24:10.318291",
  "modified_by": "Administrator",
  "module": "Shipment",
  "name": "Shipment",

--- a/shipment/shipment/doctype/shipment/shipment.py
+++ b/shipment/shipment/doctype/shipment/shipment.py
@@ -3,8 +3,24 @@
 # For license information, please see license.txt
 
 from __future__ import unicode_literals
-# import frappe
+import frappe
 from frappe.model.document import Document
+from erpnext.accounts.party import get_party_shipping_address
+from frappe.contacts.doctype.contact.contact import get_default_contact
 
 class Shipment(Document):
 	pass
+
+@frappe.whitelist()
+def get_address(ref_doctype, docname):
+	'''
+		Return address name
+	'''	
+	return get_party_shipping_address(ref_doctype, docname)
+
+@frappe.whitelist()
+def get_contact(ref_doctype, docname):
+	'''
+		Return address name
+	'''	
+	return get_default_contact(ref_doctype, docname)	

--- a/shipment/shipment/doctype/shipment_delivery_notes/shipment_delivery_notes.json
+++ b/shipment/shipment/doctype/shipment_delivery_notes/shipment_delivery_notes.json
@@ -1,12 +1,11 @@
 {
- "actions": [],
  "creation": "2020-03-27 19:36:32.752429",
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
   "delivery_note",
-  "value"
+  "grand_total"
  ],
  "fields": [
   {
@@ -19,7 +18,8 @@
    "unique": 1
   },
   {
-   "fieldname": "value",
+   "fetch_from": "delivery_note.grand_total",
+   "fieldname": "grand_total",
    "fieldtype": "Currency",
    "in_list_view": 1,
    "label": "Value",
@@ -27,8 +27,7 @@
   }
  ],
  "istable": 1,
- "links": [],
- "modified": "2020-03-27 19:38:10.646317",
+ "modified": "2020-03-28 15:20:12.652131",
  "modified_by": "Administrator",
  "module": "Shipment",
  "name": "Shipment Delivery Notes",

--- a/shipment/shipment/doctype/shipment_parcel_preset/shipment_parcel_preset.json
+++ b/shipment/shipment/doctype/shipment_parcel_preset/shipment_parcel_preset.json
@@ -1,25 +1,17 @@
 {
- "actions": [],
- "autoname": "Name",
+ "autoname": "field:preset_name",
  "creation": "2020-03-27 19:34:13.023080",
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "name1",
+  "preset_name",
   "length",
   "width",
   "height",
   "weight"
  ],
  "fields": [
-  {
-   "fieldname": "name1",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "label": "Name",
-   "reqd": 1
-  },
   {
    "fieldname": "length",
    "fieldtype": "Int",
@@ -46,10 +38,17 @@
    "fieldtype": "Float",
    "label": "Weight (kg)",
    "precision": "1"
+  },
+  {
+   "fieldname": "preset_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Preset Name",
+   "reqd": 1,
+   "unique": 1
   }
  ],
- "links": [],
- "modified": "2020-03-27 19:34:27.612936",
+ "modified": "2020-03-28 14:47:31.809981",
  "modified_by": "Administrator",
  "module": "Shipment",
  "name": "Shipment Parcel Preset",


### PR DESCRIPTION
1. On load, Pickup from is autoset to Company and Company Addess and current user as Contact Display is pulled.
2. On selection on Customer/Supplier, show only related Address and Contact
3. Autoset Address and Contact Name
4. On selection show Address Display and Contact Display
5. Contact is not mandatory if Company because users are not Contact, need to pull their information from User and show in Contact Display.
6. Set Shipment Parcel presets on selection and button press
7. Pull Delivery Note only for selected Customer, please note that we do not make Delivery Note for Suppliers yet.
8. Set Value of Goods as total of Delivery Note values
9. Set Pickup Date as tomorrow by default
10. Validation if older date is selected
11. If Pickup Date is today, autoselect preceding Pickup Time
12. Validation if older time is selected
13. Some doctype changes also (fieldnames and fieldtypes)

Some screenshots, Monospace not letting me save as gif.
<img width="1201" alt="Screen Shot 2020-03-29 at 5 51 32 PM" src="https://user-images.githubusercontent.com/16913064/77849031-532b8800-71e6-11ea-9bbc-7383903a789e.png">
<img width="1154" alt="Screen Shot 2020-03-29 at 5 52 29 PM" src="https://user-images.githubusercontent.com/16913064/77849034-57f03c00-71e6-11ea-9a24-6a3e73781648.png">
<img width="817" alt="Screen Shot 2020-03-29 at 5 52 49 PM" src="https://user-images.githubusercontent.com/16913064/77849036-5c1c5980-71e6-11ea-919f-25ec92468424.png">
<img width="817" alt="Screen Shot 2020-03-29 at 5 53 03 PM" src="https://user-images.githubusercontent.com/16913064/77849041-5fafe080-71e6-11ea-89ba-bb95319cc8bf.png">
