### PR TITLE
fix(shipment): Trigger frappe throw once

### DIFF
--- a/shipment/shipment/doctype/shipment/shipment.js
+++ b/shipment/shipment/doctype/shipment/shipment.js
@@ -166,7 +166,6 @@ frappe.ui.form.on('Shipment', {
 		if (frm.doc.pickup_from_type == 'Company') {
 			frm.set_value("pickup_company", frappe.defaults.get_default('company'));
 			frm.trigger('set_pickup_company_address');
-			frm.events.set_company_contact(frm, 'Pickup')
 			frm.set_df_property("pickup_contact_name", "reqd", 0);
 			frm.set_value("pickup_customer", '');
 			frm.set_value("pickup_supplier", '');
@@ -192,7 +191,6 @@ frappe.ui.form.on('Shipment', {
 		if (frm.doc.delivery_to_type == 'Company') {
 			frm.set_value("delivery_company", frappe.defaults.get_default('company'));
 			frm.trigger('set_delivery_company_address');
-			frm.events.set_company_contact(frm, 'Delivery')
 			frm.set_df_property("delivery_contact_name", "reqd", 0);
 			frm.set_value("delivery_customer", '');
 			frm.set_value("delivery_supplier", '');


### PR DESCRIPTION
Re: #30 

Non-destructive to the functionality since `set_company_contact` is getting called on `pickup_company` and `delivery_company` change hook.

![ship5](https://user-images.githubusercontent.com/17470909/78316162-8c227e80-7591-11ea-8e81-0fee5ca2da79.gif)
