### PR TITLE
feat(packlink): create packlink integration to shipment

### DIFF
--- a/shipment/api/packlink.py
+++ b/shipment/api/packlink.py
@@ -1,7 +1,190 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2018, ESO Electronic Service Ottenbreit GmbH
 # For license information, please see license.txt
+import frappe
+import json
+import requests
+from frappe import _
 
+def get_address(address_name):
+    return frappe.get_doc('Address', address_name)
 
-def get_packlink_available_services():
-	return
+def get_contact(contact_name):
+    contact = frappe.get_doc('Contact', contact_name)
+    contact.email = contact.email_id
+    return contact
+
+def get_company_contact():
+    return frappe.get_doc('User', frappe.session.user)
+
+def parse_pickup_date(pickup_date):
+    return pickup_date.replace('-', '/')
+
+def get_parcel_list(shipment_parcel):
+    parcel_list = []
+    for parcel in shipment_parcel:
+        for count in range(parcel.get('count')):
+            formatted_parcel = {}
+            formatted_parcel['height'] = parcel.get('height')
+            formatted_parcel['width'] = parcel.get('width')
+            formatted_parcel['length'] = parcel.get('length')
+            formatted_parcel['weight'] = parcel.get('weight')
+            parcel_list.append(formatted_parcel)
+    return parcel_list
+
+def get_packlink_available_services(
+    pickup_address_name, 
+    delivery_address_name,
+    shipment_parcel,
+    pickup_date
+    ):
+    pickup_address = frappe.get_doc('Address', pickup_address_name)
+    from_zip = pickup_address.pincode
+    from_country_code = frappe.get_value('Country', pickup_address.country, 'code').upper()
+
+    delivery_address = frappe.get_doc('Address', delivery_address_name)
+    to_zip = delivery_address.pincode
+    to_country_code = frappe.get_value('Country', delivery_address.country, 'code').upper()
+
+    shipment_parcel_params = ''
+    for index, parcel in enumerate(get_parcel_list(json.loads(shipment_parcel))):
+        shipment_parcel_params += 'packages[{index}][height]={height}&packages[{index}][length]={length}&packages[{index}][weight]={weight}&packages[{index}][width]={width}&'.format(
+            index = index, 
+            height = parcel['height'], 
+            length = parcel['length'],
+            weight = parcel['weight'],
+            width = parcel['width']
+        )
+    
+    url = 'https://api.packlink.com/v1/services?from[country]={}&from[zip]={}&to[country]={}&to[zip]={}&{}sortBy=totalPrice&source=PRO'.format(
+            from_country_code, from_zip, to_country_code, to_zip, shipment_parcel_params
+    )
+    api_key = frappe.db.get_value('Shipment Service Provider', 'Packlink', 'api_key')
+
+    try:
+        responses = requests.get(url, headers={'Authorization': api_key})
+        responses_dict = json.loads(responses.text)
+
+        # If an error occured on the api. Show the error message
+        if 'messages' in responses_dict:
+            frappe.msgprint(
+                _('Packlink: {0}'.format(str(responses_dict['messages'][0]['message']))), 
+                indicator='orange',
+                alert=True
+            )
+            return []
+
+        available_services = []
+        for response in responses_dict:
+            if parse_pickup_date(pickup_date) in response['available_dates'].keys():
+                available_service = frappe._dict()
+                available_service.service_provider = 'Packlink'
+                available_service.service_name = response['name']
+                available_service.carrier = response['carrier_name']
+                available_service.total_price = response['price']['total_price']
+                available_service.service_id = response['id']
+                available_service.available_dates = response['available_dates']
+                available_services.append(available_service)
+
+        return available_services
+    except Exception as exc:
+        frappe.msgprint(
+            _('Error occurred on Packlink: {0}').format(str(exc)), 
+            indicator='orange',
+            alert=True
+        )
+        return []
+
+def create_packlink_shipment(
+    pickup_from_type,
+    delivery_to_type,
+    pickup_address_name,
+    delivery_address_name,
+    shipment_parcel,
+    description_of_content,
+    pickup_date,
+    value_of_goods,
+    pickup_contact_name,
+    delivery_contact_name,
+    service_info
+    ):
+    api_key = frappe.db.get_value('Shipment Service Provider', 'Packlink', 'api_key')
+
+    pickup_address = get_address(pickup_address_name)
+    from_country_code = frappe.get_value('Country', pickup_address.country, 'code').upper()
+    if pickup_from_type != 'Company':
+        pickup_contact = get_contact(pickup_contact_name)
+    else:
+        pickup_contact = get_company_contact()
+
+    delivery_address = get_address(delivery_address_name)
+    to_country_code = frappe.get_value('Country', delivery_address.country, 'code').upper()
+    if delivery_to_type != 'Company':
+        delivery_contact = get_contact(delivery_contact_name)
+    else:
+        delivery_contact = get_company_contact()
+
+    data = {
+        "additional_data": {
+            "postal_zone_id_from": "",
+            "postal_zone_name_from": pickup_address.country,
+            "postal_zone_id_to": "",
+            "postal_zone_name_to": delivery_address.county
+        },
+        "collection_date": parse_pickup_date(pickup_date),
+        "collection_time": "",
+        "content": description_of_content,
+        "contentvalue": value_of_goods,
+        "content_second_hand": False,
+        "from": {
+            "city": pickup_address.city,
+            "company": pickup_address.address_title,
+            "country": from_country_code,
+            "email": pickup_contact.email,
+            "name": pickup_contact.first_name,
+            "phone": pickup_contact.phone,
+            "state": pickup_address.country,
+            "street1": pickup_address.address_line1,
+            "surname": pickup_contact.last_name,
+            "zip_code": pickup_address.pincode
+        },
+        "insurance": {
+            "amount": 0,
+            "insurance_selected": False
+        },
+        "price": {},
+        "packages": get_parcel_list(json.loads(shipment_parcel)),
+        "service_id": service_info['service_id'],
+        "to": {
+            "city": delivery_address.city,
+            "company": delivery_address.address_title,
+            "country": to_country_code,
+            "email": delivery_contact.email,
+            "name": delivery_contact.first_name,
+            "phone": delivery_contact.phone,
+            "state": delivery_address.country,
+            "street1": delivery_address.address_line1,
+            "surname": delivery_contact.last_name,
+            "zip_code": delivery_address.pincode
+        }
+    }
+
+    url = 'https://api.packlink.com/v1/shipments'
+    headers = {'Authorization': api_key, 'Content-Type': 'application/json'}
+
+    try:
+        warehouse_id_response = requests.post(url, json = data, headers=headers)
+        warehouse_id = json.loads(warehouse_id_response.text)
+        response_data = {
+            'service_provider': 'Packlink',
+            'shipment_id': warehouse_id['reference'],
+            'carrier': service_info['carrier'],
+            'carrier_service': service_info['service_name'],
+        }
+        return response_data
+    except Exception as exc:
+        frappe.msgprint(
+            _('Error occurred while creating Shipment: {0}').format(str(exc)), 
+            indicator='orange',
+            alert=True
+        )

--- a/shipment/shipment/doctype/shipment/shipment.py
+++ b/shipment/shipment/doctype/shipment/shipment.py
@@ -13,7 +13,6 @@ from frappe.model.document import Document
 from erpnext.accounts.party import get_party_shipping_address
 from frappe.contacts.doctype.contact.contact import get_default_contact
 
-
 class Shipment(Document):
     def on_submit(self):
         if not self.shipment_parcel:
@@ -24,7 +23,7 @@ class Shipment(Document):
 
 def get_address(address_name):
     address = frappe.db.get_value('Address', address_name,
-                                  ['address_line1', 'address_line2',
+                                  ['address_title', 'address_line1', 'address_line2',
                                   'city', 'pincode', 'country'],
                                   as_dict=1)
     address.country_code = frappe.db.get_value('Country',
@@ -322,6 +321,179 @@ def get_contact_name(ref_doctype, docname):
     return get_default_contact(ref_doctype, docname)
 
 
+#Packlink
+def parse_pickup_date(pickup_date):
+    return pickup_date.replace('-', '/')
+
+def packlink_get_parcel_list(shipment_parcel):
+    parcel_list = []
+    for parcel in shipment_parcel:
+        for count in range(parcel.get('count')):
+            formatted_parcel = {}
+            formatted_parcel['height'] = parcel.get('height')
+            formatted_parcel['width'] = parcel.get('width')
+            formatted_parcel['length'] = parcel.get('length')
+            formatted_parcel['weight'] = parcel.get('weight')
+            parcel_list.append(formatted_parcel)
+    return parcel_list
+
+def get_packlink_available_services(
+    pickup_address_name, 
+    delivery_address_name,
+    shipment_parcel,
+    pickup_date
+    ):
+    pickup_address = get_address(pickup_address_name)
+    from_zip = pickup_address.pincode
+    from_country_code = pickup_address.country_code
+
+    delivery_address = get_address(delivery_address_name)
+    to_zip = delivery_address.pincode
+    to_country_code = delivery_address.country_code
+
+    shipment_parcel_params = ''
+    for index, parcel in enumerate(packlink_get_parcel_list(json.loads(shipment_parcel))):
+        shipment_parcel_params += 'packages[{index}][height]={height}&packages[{index}][length]={length}&packages[{index}][weight]={weight}&packages[{index}][width]={width}&'.format(
+            index = index, 
+            height = parcel['height'], 
+            length = parcel['length'],
+            weight = parcel['weight'],
+            width = parcel['width']
+        )
+    
+    url = 'https://api.packlink.com/v1/services?from[country]={}&from[zip]={}&to[country]={}&to[zip]={}&{}sortBy=totalPrice&source=PRO'.format(
+            from_country_code, from_zip, to_country_code, to_zip, shipment_parcel_params
+    )
+    api_key = frappe.db.get_value('Shipment Service Provider', 'Packlink', 'api_key')
+
+    try:
+        responses = requests.get(url, headers={'Authorization': api_key})
+        responses_dict = json.loads(responses.text)
+
+        # If an error occured on the api. Show the error message
+        if 'messages' in responses_dict:
+            frappe.msgprint(
+                _('Packlink: {0}'.format(str(responses_dict['messages'][0]['message']))), 
+                indicator='orange',
+                alert=True
+            )
+            return []
+
+        available_services = []
+        for response in responses_dict:
+            if parse_pickup_date(pickup_date) in response['available_dates'].keys():
+                available_service = frappe._dict()
+                available_service.service_provider = 'Packlink'
+                available_service.service_name = response['name']
+                available_service.carrier = response['carrier_name']
+                available_service.total_price = response['price']['total_price']
+                available_service.service_id = response['id']
+                available_service.available_dates = response['available_dates']
+                available_services.append(available_service)
+
+        return available_services
+    except Exception as exc:
+        frappe.msgprint(
+            _('Error occurred on Packlink: {0}').format(str(exc)), 
+            indicator='orange',
+            alert=True
+        )
+        return []
+
+def create_packlink_shipment(
+    pickup_from_type,
+    delivery_to_type,
+    pickup_address_name,
+    delivery_address_name,
+    shipment_parcel,
+    description_of_content,
+    pickup_date,
+    value_of_goods,
+    pickup_contact_name,
+    delivery_contact_name,
+    service_info
+    ):
+    api_key = frappe.db.get_value('Shipment Service Provider', 'Packlink', 'api_key')
+
+    pickup_address = get_address(pickup_address_name)
+    from_country_code = pickup_address.country_code
+    if pickup_from_type != 'Company':
+        pickup_contact = get_contact(pickup_contact_name)
+    else:
+        pickup_contact = get_company_contact()
+
+    delivery_address = get_address(delivery_address_name)
+    to_country_code = delivery_address.country_code
+    if delivery_to_type != 'Company':
+        delivery_contact = get_contact(delivery_contact_name)
+    else:
+        delivery_contact = get_company_contact()
+
+    data = {
+        "additional_data": {
+            "postal_zone_id_from": "",
+            "postal_zone_name_from": pickup_address.country,
+            "postal_zone_id_to": "",
+            "postal_zone_name_to": delivery_address.country
+        },
+        "collection_date": parse_pickup_date(pickup_date),
+        "collection_time": "",
+        "content": description_of_content,
+        "contentvalue": value_of_goods,
+        "content_second_hand": False,
+        "from": {
+            "city": pickup_address.city,
+            "company": pickup_address.address_title,
+            "country": from_country_code,
+            "email": pickup_contact.email,
+            "name": pickup_contact.first_name,
+            "phone": pickup_contact.phone,
+            "state": pickup_address.country,
+            "street1": pickup_address.address_line1,
+            "surname": pickup_contact.last_name,
+            "zip_code": pickup_address.pincode
+        },
+        "insurance": {
+            "amount": 0,
+            "insurance_selected": False
+        },
+        "price": {},
+        "packages": packlink_get_parcel_list(json.loads(shipment_parcel)),
+        "service_id": service_info['service_id'],
+        "to": {
+            "city": delivery_address.city,
+            "company": delivery_address.address_title,
+            "country": to_country_code,
+            "email": delivery_contact.email,
+            "name": delivery_contact.first_name,
+            "phone": delivery_contact.phone,
+            "state": delivery_address.country,
+            "street1": delivery_address.address_line1,
+            "surname": delivery_contact.last_name,
+            "zip_code": delivery_address.pincode
+        }
+    }
+
+    url = 'https://api.packlink.com/v1/shipments'
+    headers = {'Authorization': api_key, 'Content-Type': 'application/json'}
+
+    try:
+        warehouse_id_response = requests.post(url, json = data, headers=headers)
+        warehouse_id = json.loads(warehouse_id_response.text)
+        response_data = {
+            'service_provider': 'Packlink',
+            'shipment_id': warehouse_id['reference'],
+            'carrier': service_info['carrier'],
+            'carrier_service': service_info['service_name'],
+        }
+        return response_data
+    except Exception as exc:
+        frappe.msgprint(
+            _('Error occurred while creating Shipment: {0}').format(str(exc)), 
+            indicator='orange',
+            alert=True
+        )
+
 @frappe.whitelist()
 def fetch_shipping_rates(
     pickup_from_type,
@@ -349,7 +521,13 @@ def fetch_shipping_rates(
         pickup_contact_name=pickup_contact_name,
         delivery_contact_name=delivery_contact_name,
         )
-    return letmeship_prices
+    packlink_prices = get_packlink_available_services(
+        pickup_address_name=pickup_address_name,
+        delivery_address_name=delivery_address_name,
+        shipment_parcel=shipment_parcel,
+        pickup_date=pickup_date
+    )
+    return letmeship_prices + packlink_prices
 
 
 @frappe.whitelist()
@@ -388,4 +566,19 @@ def create_shipment(
             shipment_notific_email=shipment_notific_email,
             tracking_notific_email=tracking_notific_email,
             )
+    
+    if service_info['service_provider'] == 'Packlink':
+        shipment_info = create_packlink_shipment(
+            pickup_from_type=pickup_from_type,
+            delivery_to_type=delivery_to_type,
+            pickup_address_name=pickup_address_name,
+            delivery_address_name=delivery_address_name,
+            shipment_parcel=shipment_parcel,
+            description_of_content=description_of_content,
+            pickup_date=pickup_date,
+            value_of_goods=value_of_goods,
+            pickup_contact_name=pickup_contact_name,
+            delivery_contact_name=delivery_contact_name,
+            service_info=service_info
+        )
     return shipment_info


### PR DESCRIPTION
Re: #15 

Will create a shipment draft in packlink after picking a packlink shipment service.

Needs to generate an api key on packlink pro. Create an item in `Shipment Service Provider` doctype named `Packlink` and put in the `API key` field your generated API Key

<img width="1609" alt="Packlink 2020-04-16 12-30-51" src="https://user-images.githubusercontent.com/17470909/79414809-319c1000-7fde-11ea-94c2-06b6e3ec2e24.png">

![shipment](https://user-images.githubusercontent.com/17470909/79324665-8427ee80-7f42-11ea-9c38-56551fcab1eb.gif)
