### PR TITLE
fix(Shipment): Trim spaces from zipcode

### DIFF
--- a/shipment/shipment/doctype/shipment/shipment.py
+++ b/shipment/shipment/doctype/shipment/shipment.py
@@ -43,6 +43,7 @@ def get_address(address_name):
         ], as_dict=1)
     address.country_code = frappe.db.get_value('Country',
             address.country, 'code').upper()
+    address.pincode = address.pincode.replace(" ", "")
     return address
 
 


### PR DESCRIPTION
Using replace so that no spaces in between as well.

re: #67