### PR TITLE
fix(Shipment): Fix Contact error, set preset

### DIFF
--- a/shipment/shipment/doctype/shipment/shipment.js
+++ b/shipment/shipment/doctype/shipment/shipment.js
@@ -4,7 +4,7 @@
 frappe.ui.form.on('Shipment', {
 	setup: function(frm) {
 		if (frm.doc.__islocal) {
-			frm.set_value("pickup_date", frappe.datetime.add_days(frappe.datetime.get_today(), 1));
+			frm.set_value("pickup_date", frappe.datetime.get_today());
 		}
 	},
 	address_query: function(frm, link_doctype, link_name, is_your_company_address) {
@@ -255,7 +255,7 @@ frappe.ui.form.on('Shipment', {
 							frm.set_value('pickup_contact_name', '')
 							frm.set_value('pickup_contact', '')
 						}
-						frappe.throw(__(`Email and Phone/Mobile of the Contact are mandatory to continue. </br>
+						frappe.throw(__(`Email or Phone/Mobile of the Contact are mandatory to continue. </br>
 							Please set Email/Phone for the contact <a href="#Form/Contact/${contact_name}">${contact_name}</a>`))
 					}
 					let contact_display = r.message.contact_display
@@ -295,8 +295,8 @@ frappe.ui.form.on('Shipment', {
 		}
 	},
 	set_company_contact: function(frm, delivery_type) {
-        frappe.db.get_value('User', {name: frappe.session.user}, ['full_name', 'email', 'phone', 'mobile_no'], (r) => {
-			if (!(r.email && (r.phone || r.mobile_no))) {
+        frappe.db.get_value('User', {name: frappe.session.user}, ['full_name', 'last_name', 'email', 'phone', 'mobile_no'], (r) => {
+			if (!(r.last_name && r.email && (r.phone || r.mobile_no))) {
 				if (delivery_type == 'Delivery') {
 					frm.set_value('delivery_company', '')
 					frm.set_value('delivery_contact', '')
@@ -305,8 +305,8 @@ frappe.ui.form.on('Shipment', {
 					frm.set_value('pickup_company', '')
 					frm.set_value('pickup_contact', '')
 				}
-				frappe.throw(__(`Email and Phone/Mobile of the user are mandatory to continue. </br>
-					Please first set Email/Phone for the user <a href="#Form/User/${frappe.session.user}">${frappe.session.user}</a>`))
+				frappe.throw(__(`Last Name, Email or Phone/Mobile of the user are mandatory to continue. </br>
+					Please first set Last Name, Email and Phone for the user <a href="#Form/User/${frappe.session.user}">${frappe.session.user}</a>`))
 			}
 			let contact_display = r.full_name
 			if (r.email) {
@@ -621,6 +621,11 @@ frappe.ui.form.on('Shipment Delivery Notes', {
 							frm.set_value('pickup_contact', contact_display)
 							frm.set_value('pickup_contact_email', 'service@eso-hygiene.com')
 				        });
+						if (r.message.qty == 10) {
+							frm.set_value('preset', 'Faltkarton 4')
+							frm.refresh_fields("preset")
+							frm.trigger('add_preset')
+						}
 					}
 				}
 			});

--- a/shipment/shipment/doctype/shipment/shipment_service_selector.html
+++ b/shipment/shipment/doctype/shipment/shipment_service_selector.html
@@ -1,4 +1,28 @@
+{% if (data.length) { %}
 <div style="overflow-x:scroll;height: 550px;">
+    <h5>{{ __("Preferred Services") }}</h5>
+    <table class="table table-bordered table-hover">
+        <thead class="grid-heading-row">
+            <tr style="text-align: center">
+                {% for (var i = 0; i < header_columns.length; i++) { %} <th style="text-align: center">{{ header_columns[i] }}</th>
+                    {% } %}
+            </tr>
+        </thead>
+        <tbody>
+            {% for (var i = 0; i < data.length; i++) { %} {% if (data[i].is_preferred) { %} <tr style="text-align: center" id="data-list-{{i}}">
+                <td style="width:20%">{{ data[i].service_provider }}</td>
+                <td style="width:20%">{{ data[i].carrier }}</td>
+                <td style="width:40%">{{ data[i].service_name }}</td>
+                <td style="width:10%">{{ format_currency(data[i].total_price, 'EUR', 2) }}</td>
+                <td style="width:10%">
+                    <button id="data-list-{{i}}" onclick='cur_frm.select_row({{JSON.stringify(data[i])}})' type="button" class="btn btn-success"><span class="glyphicon glyphicon-check"></button>
+                </td>
+			  </tr>
+   {% } %}
+			{% } %}
+  </tbody>
+</table>
+<h5>{{ __("Other Services") }}</h5>
 	<table class="table table-bordered table-hover">
   <thead class="grid-heading-row">
     <tr style="text-align: center">
@@ -8,24 +32,26 @@
     </tr>
   </thead>
   <tbody>
-	  {% if (data.length)  %}
 		  {% for (var i = 0; i < data.length; i++) { %}
+				{% if (!data[i].is_preferred) { %}
 			  <tr style="text-align: center" id="data-list-{{i}}">
-				<td>{{ data[i].service_provider }}</td>
-				<td>{{ data[i].carrier }}</td>
-				<td>{{ data[i].service_name }}</td>
-				<td>{{ format_currency(data[i].total_price, 'EUR', 2) }}</td>
-				<td>
+				<td style="width:20%">{{ data[i].service_provider }}</td>
+				<td style="width:20%">{{ data[i].carrier }}</td>
+				<td style="width:40%">{{ data[i].service_name }}</td>
+				<td style="width:10%">{{ format_currency(data[i].total_price, 'EUR', 2) }}</td>
+				<td style="width:10%">
                     <button id="data-list-{{i}}" onclick='cur_frm.select_row({{JSON.stringify(data[i])}})' type="button" class="btn btn-success"><span class="glyphicon glyphicon-check"></button>
                 </td>
 			  </tr>
-		  {% } %}
-	  {% }  else { %}
-	  	     <td style="text-align:center"  colspan="6" style="text-align:center;"> <br><b class="text-muted">{% __("No Available Services")%} </b> </td>
-	  {% } %}
+			{% } %}
+			{% } %}
   </tbody>
 </table>
 </div>
+{% }  else { %}
+ <div> <b class="text-muted">{{ __("No Services Available") }} </b> </div>
+{% } %}
+
 <style type="text/css" media="screen">
 .modal-dialog {
     width: 750px;
@@ -34,4 +60,4 @@
 .table > tbody > tr > td, .table > tfoot > tr > td {
 	    padding: 4px;
 }
-</style>	
+</style>


### PR DESCRIPTION
Error message in Delivery Note itself
re: https://github.com/newmatik/newmatik/issues/3024
<img width="930" alt="Screen Shot 2020-04-30 at 4 19 31 PM" src="https://user-images.githubusercontent.com/16913064/80702288-7788c600-8afe-11ea-983f-a1afddd01883.png">

Error message on Shipment for direct created Shipments
re: #82 
<img width="955" alt="Screen Shot 2020-04-30 at 4 23 46 PM" src="https://user-images.githubusercontent.com/16913064/80702606-f978ef00-8afe-11ea-87a5-18d798cacac9.png">


Add preset when created from Delivery Note or when created manually and delivery note is selected:
re: #83 
<img width="614" alt="Screen Shot 2020-04-30 at 4 05 50 PM" src="https://user-images.githubusercontent.com/16913064/80702303-7b1c4d00-8afe-11ea-8d64-24e8ae1e0149.png">

Pickup Date set to today:
re: #80 

<img width="645" alt="Screen Shot 2020-04-30 at 4 29 32 PM" src="https://user-images.githubusercontent.com/16913064/80703101-c8e58500-8aff-11ea-9f58-541b6f6497ef.png">

Show Preferred Service on top in different table, also match alias:
re: https://github.com/newmatik/shipment/issues/66, https://github.com/newmatik/shipment/issues/61
Need to match data

<img width="804" alt="Screen Shot 2020-05-04 at 1 23 44 AM" src="https://user-images.githubusercontent.com/16913064/80924320-e8054080-8da5-11ea-8b00-6e0b242934ec.png">
