### PR TITLE
fix(Shipment): Contact not mandatory for Company

### DIFF
--- a/shipment/api/utils.py
+++ b/shipment/api/utils.py
@@ -65,6 +65,8 @@ def get_company_contact():
     ], as_dict=1)
     if not contact.phone:
         contact.phone = contact.mobile_no
+    if not contact.phone:
+        contact.phone = "+49675216998"
     contact.phone_prefix = contact.phone[:3]
     contact.phone = re.sub('[^A-Za-z0-9]+', '', contact.phone[3:])
     contact.title = 'MS'

--- a/shipment/shipment/doctype/shipment/shipment.js
+++ b/shipment/shipment/doctype/shipment/shipment.js
@@ -153,10 +153,15 @@ frappe.ui.form.on('Shipment', {
 		if (frm.doc.delivery_from_type != 'Company') {
 			frm.set_df_property("delivery_contact_name", "reqd", 1);
 		}
+		else {
+			frm.set_df_property("delivery_contact_name", "reqd", 0);
+			frm.toggle_display("delivery_contact_name", false)
+		}
 		if (frm.doc.pickup_from_type != 'Company') {
 			frm.set_df_property("pickup_contact_name", "reqd", 1);
 		}
 		else {
+			frm.set_df_property("delivery_contact_name", "reqd", 0);
 			frm.toggle_display("pickup_contact_name", false)
 		}
 	},
@@ -223,6 +228,7 @@ frappe.ui.form.on('Shipment', {
 			frm.set_value("delivery_customer", '');
 			frm.set_value("delivery_supplier", '');
 			frm.toggle_display("delivery_contact_name", false)
+			frm.trigger('delivery_company')
 		}
 		else {
 			frm.set_df_property("delivery_contact_name", "reqd", 1);
@@ -316,7 +322,7 @@ frappe.ui.form.on('Shipment', {
 	},
 	set_company_contact: function(frm, delivery_type) {
         frappe.db.get_value('User', {name: frappe.session.user}, ['full_name', 'last_name', 'email', 'phone', 'mobile_no'], (r) => {
-			if (!(r.last_name && r.email && (r.phone || r.mobile_no))) {
+			if (!(r.last_name)) {
 				if (delivery_type == 'Delivery') {
 					frm.set_value('delivery_company', '')
 					frm.set_value('delivery_contact', '')
@@ -325,8 +331,8 @@ frappe.ui.form.on('Shipment', {
 					frm.set_value('pickup_company', '')
 					frm.set_value('pickup_contact', '')
 				}
-				frappe.throw(__(`Last Name, Email or Phone/Mobile of the user are mandatory to continue. </br>
-					Please first set Last Name, Email and Phone for the user <a href="#Form/User/${frappe.session.user}">${frappe.session.user}</a>`))
+				frappe.throw(__(`Last Name of the user are mandatory to continue. </br>
+					Please first set Last Name for the user <a href="#Form/User/${frappe.session.user}">${frappe.session.user}</a>`))
 			}
 			let contact_display = r.full_name
 			if (r.email) {


### PR DESCRIPTION
- Not all ESO employees have email and phone numbers hence removed the validation and added a default phone number, we already have an email set.
- We do set delivery_contact_name as not required if it company but on refresh, it gets reset so added it to refresh as well
- Also, the address was not being auto pulled, added a trigger for that.

re: #106 