### PR TITLE
refactor(let_me_ship.py&utils.py): added state and remove space in contact prefix

### DIFF
--- a/shipment/api/let_me_ship.py
+++ b/shipment/api/let_me_ship.py
@@ -45,6 +45,12 @@ def get_letmeship_available_services(
         delivery_address.address_title = \
             delivery_address.address_title[:30]
 
+    if not delivery_address.state:
+        frappe.throw(_("Please set the state for the shipping address for {0}").format(delivery_address.address_title))
+
+    if len(delivery_address.state) > 3:
+        frappe.throw(_("State must be in abbreviation for {0}").format(delivery_address.address_title))
+
     pickupOrder = False
     if pickup_type and pickup_type == "Pickup":
         pickupOrder = True
@@ -76,7 +82,8 @@ def get_letmeship_available_services(
                    'firstname': pickup_contact.first_name,
                    'lastname': pickup_contact.last_name},
         'phone': {'phoneNumber': pickup_contact.phone,
-                  'phoneNumberPrefix': pickup_contact.phone_prefix},
+                  'phoneNumberPrefix': pickup_contact.phone_prefix.replace(" ", "")
+                  if ' ' in pickup_contact.phone_prefix else pickup_contact.phone_prefix},
         'email': pickup_contact.email,
     }, 'deliveryInfo': {
         'address': {
@@ -86,13 +93,15 @@ def get_letmeship_available_services(
             'street': delivery_address.address_line1,
             'addressInfo1': delivery_address.address_line2,
             'houseNo': '',
+            'stateCode': delivery_address.state
         },
         'company': delivery_address.address_title,
         'person': {'title': delivery_contact.title,
                    'firstname': delivery_contact.first_name,
                    'lastname': delivery_contact.last_name},
         'phone': {'phoneNumber': delivery_contact.phone,
-                  'phoneNumberPrefix': delivery_contact.phone_prefix},
+                  'phoneNumberPrefix': delivery_contact.phone_prefix.replace(" ", "")
+                  if ' ' in delivery_contact.phone_prefix else delivery_contact.phone_prefix},
         'email': delivery_contact.email,
     }, 'shipmentDetails': {
         'contentDescription': description_of_content,

--- a/shipment/api/utils.py
+++ b/shipment/api/utils.py
@@ -18,6 +18,7 @@ def get_address(address_name):
         'city',
         'pincode',
         'country',
+        'state'
     ], as_dict=1)
     address.country_code = frappe.db.get_value('Country',
                                                address.country, 'code').upper()


### PR DESCRIPTION
[Issue#120](https://github.com/elexess/erp-shipment/issues/120)

The reason for the error is that the payload for let_me_ship in phoneNumberPrefix in deliveryInfo has space and let_me_ship doesn't allow spaces so what I did is check the prefix if it has space then remove it. While on the state error there's no state on our payload so I added state

![shipment](https://user-images.githubusercontent.com/40702858/130384756-51d69831-f402-491d-99e9-867e5b97c6cf.gif)
