### PR TITLE
refactor(let_me_ship.py): remove the validation created change payload for creating shipment

### DIFF
--- a/shipment/api/let_me_ship.py
+++ b/shipment/api/let_me_ship.py
@@ -45,11 +45,13 @@ def get_letmeship_available_services(
         delivery_address.address_title = \
             delivery_address.address_title[:30]
 
-    if not delivery_address.state:
-        frappe.throw(_("Please set the state for the shipping address for {0}").format(delivery_address.address_title))
+    if len(delivery_address.address_line1) > 35:
+        counter = 35
+        while delivery_address.address_line1[counter] != " ":
+            counter -= 1
 
-    if len(delivery_address.state) > 3:
-        frappe.throw(_("State must be in abbreviation for {0}").format(delivery_address.address_title))
+        delivery_address.update({"address_line1_con": delivery_address.address_line1[counter + 1:len(delivery_address.address_line1) - 1]})
+        delivery_address.address_line1 = delivery_address.address_line1[:counter]
 
     pickupOrder = False
     if pickup_type and pickup_type == "Pickup":
@@ -91,7 +93,8 @@ def get_letmeship_available_services(
             'zip': delivery_address.pincode,
             'city': delivery_address.city,
             'street': delivery_address.address_line1,
-            'addressInfo1': delivery_address.address_line2,
+            'addressInfo1': delivery_address.address_line2 if 'address_line1_con' not in delivery_address else delivery_address.address_line1_con,
+            "addressInfo2": '' if 'address_line1_con' not in delivery_address else delivery_address.address_line2,
             'houseNo': '',
             'stateCode': delivery_address.state
         },
@@ -193,6 +196,14 @@ def create_letmeship_shipment(
         delivery_address.address_title = \
             delivery_address.address_title[:30]
 
+    if len(delivery_address.address_line1) > 35:
+        counter = 35
+        while delivery_address.address_line1[counter] != " ":
+            counter -= 1
+
+        delivery_address.update({"address_line1_con": delivery_address.address_line1[counter + 1:len(delivery_address.address_line1) - 1]})
+        delivery_address.address_line1 = delivery_address.address_line1[:counter]
+
     pickupOrder = False
     if pickup_type and pickup_type == "Pickup":
         pickupOrder = True
@@ -224,7 +235,7 @@ def create_letmeship_shipment(
                        'firstname': pickup_contact.first_name,
                        'lastname': pickup_contact.last_name},
             'phone': {'phoneNumber': pickup_contact.phone,
-                      'phoneNumberPrefix': pickup_contact.phone_prefix},
+                      'phoneNumberPrefix': pickup_contact.phone_prefix.replace(" ", "") if ' ' in pickup_contact.phone_prefix else pickup_contact.phone_prefix},
             'email': pickup_contact.email,
         },
         'deliveryInfo': {
@@ -233,8 +244,10 @@ def create_letmeship_shipment(
                 'zip': delivery_address.pincode,
                 'city': delivery_address.city,
                 'street': delivery_address.address_line1,
-                'addressInfo1': delivery_address.address_line2,
+                'addressInfo1': delivery_address.address_line2 if 'address_line1_con' not in delivery_address else delivery_address.address_line1_con,
+                'addressInfo2': '' if 'address_line1_con' not in delivery_address else delivery_address.address_line2,
                 'houseNo': '',
+                'stateCode': delivery_address.state
             },
             'company': delivery_address.address_title,
             'person': {'title': delivery_contact.title,


### PR DESCRIPTION
[Issue#120](https://github.com/elexess/erp-shipment/issues/120)

On my previous [PR](https://github.com/elexess/erp-shipment/pull/121) I added validation to check state which I should not cos not every country has a state so I remove it,  it is the reason why it created an error when Timothy test it and use China as the address.

I updated the payload for create_letmeship_shipment it should be the same payload in get_letmeship_available_services cos it will throw the same error from get_letmeship_available_services. And I also added a code to handle addresses that has more than 35 character cos it letmeship only allow 35 characters.

Error when payload for creating shipment is not updated:
![error when shipment not updated](https://user-images.githubusercontent.com/40702858/130896142-327e4dab-e6e3-47b6-b1f2-2e6df92c6114.gif)
PS: I didn't try creating shipment again after changing it, cos it will create a shipment in letmeship 

Error when more than 35 characters address:
![error 35 char](https://user-images.githubusercontent.com/40702858/130896364-6d28666c-404b-403c-8414-a8080fed1abe.gif)

**After adding/changing code and removing validations I previously add**
China- more than 35 char address:
![China](https://user-images.githubusercontent.com/40702858/130896445-3057c6ab-57a9-4097-bd73-2d9ec6aa7e67.gif)

US - state 
![US](https://user-images.githubusercontent.com/40702858/130896456-736e7b42-748b-4795-a4a6-ca7625d6cf0e.gif)

Germany
![Germany](https://user-images.githubusercontent.com/40702858/130896490-dacaa7f0-c216-40f9-8571-33c2d82ec143.gif)
