### PR TITLE
refactor(shipment.py): change the validation

### DIFF
--- a/shipment/shipment/doctype/shipment/shipment.py
+++ b/shipment/shipment/doctype/shipment/shipment.py
@@ -33,10 +33,10 @@ class Shipment(Document):
             frappe.throw(_('Value of goods cannot be 0'))
         pickup_address = get_address(self.pickup_address_name)
         delivery_address = get_address(self.delivery_address_name)
-        if len(pickup_address.address_title) > 30:
-            frappe.throw(_('Maximum length of Street is 30 characters'))
-        if len(delivery_address.address_title) > 30:
-            frappe.throw(_('Maximum length of Street is 30 characters'))
+        if len(pickup_address.address_line1) > 35:
+            frappe.throw(_('Maximum length of address line 1 for pickup address is 35 characters'))
+        if len(delivery_address.address_line1) > 35:
+            frappe.throw(_('Maximum length of address line 1 for delivery address is 35 characters'))
         self.status = 'Submitted'
 
     def on_cancel(self):


### PR DESCRIPTION
[Issue#123](https://github.com/elexess/erp-shipment/issues/123)

Change the field that is being validated from "address_title"  to "address_line1" since the address_line1 is the one that is being put for "street" payload for the letmeship API

![change the validation](https://user-images.githubusercontent.com/40702858/131429330-70211587-5b75-49e7-807a-bdbbdcdcd5ed.gif)

when address_line1 is more than 35 characters the validation will show
![validation](https://user-images.githubusercontent.com/40702858/131429382-ba184217-2fe5-40ea-a5ac-db73da1e9393.gif)
