### PR TITLE
refactor: added a code to check delivery notes type being passed

### DIFF
--- a/shipment/shipment/doctype/shipment/shipment.py
+++ b/shipment/shipment/doctype/shipment/shipment.py
@@ -202,8 +202,13 @@ def update_delivery_note(delivery_notes, shipment_info=None,
         Using db_set since some services might not exist
     """
 
-    for delivery_note in delivery_notes:
-        dl_doc = frappe.get_doc('Delivery Note', delivery_note.delivery_note)
+    if type(delivery_notes) != str:
+        delivery_notes_ = '["'+delivery_notes[0].delivery_note+'"]'
+    else:
+        delivery_notes_ = delivery_notes
+
+    for delivery_note in json.loads(delivery_notes_):
+        dl_doc = frappe.get_doc('Delivery Note', delivery_note)
 
         if shipment_info:
             dl_doc.db_set('delivery_type', 'Parcel Service')


### PR DESCRIPTION
[Issue#127](https://github.com/elexess/erp-shipment/issues/127)

The reason why it gives an error during creating shipment is that the data type that is being passed for updating delivery note is a string and since the code was change from looping into JSON to looping into an object it gives an error

So what I did, I put back the old code which is the JSON thingy, and then added an if and else if to check the data type that is being passed.

https://www.loom.com/share/607f665afac543cab2ccba24ac3e29c0