### PR TITLE
fix(let_me_ship.py): handle ' ' to not trigger error

### DIFF
--- a/shipment/api/let_me_ship.py
+++ b/shipment/api/let_me_ship.py
@@ -97,7 +97,7 @@ def get_letmeship_available_services(
             'addressInfo1': delivery_address.address_line2 if 'address_line1_con' not in delivery_address else delivery_address.address_line1_con,
             "addressInfo2": '' if 'address_line1_con' not in delivery_address else delivery_address.address_line2,
             'houseNo': '',
-            'stateCode': delivery_address.state
+            'stateCode': delivery_address.state if delivery_address.state != '' else None
         },
         'company': delivery_address.address_title,
         'person': {'title': delivery_contact.title,
@@ -250,7 +250,7 @@ def create_letmeship_shipment(
                 'addressInfo1': delivery_address.address_line2 if 'address_line1_con' not in delivery_address else delivery_address.address_line1_con,
                 'addressInfo2': '' if 'address_line1_con' not in delivery_address else delivery_address.address_line2,
                 'houseNo': '',
-                'stateCode': delivery_address.state
+                'stateCode': delivery_address.state if delivery_address.state != '' else None
             },
             'company': delivery_address.address_title,
             'person': {'title': delivery_contact.title,


### PR DESCRIPTION
Asana: https://app.asana.com/0/1202487840949165/1204018948323222/f

The reason of the error is that there are data in the database that was saved as " " and it is causing an error because let me ship treat it is a data. So to not trigger the error, I added a code to handle " " and set it as None


https://user-images.githubusercontent.com/40702858/220553802-a13bce5a-e159-4a81-9f75-52b55e368844.mov

