### PR TITLE
WIP(shipment): added exworks as shipment option

### DIFF
--- a/shipment/api/let_me_ship.py
+++ b/shipment/api/let_me_ship.py
@@ -23,7 +23,8 @@ def get_letmeship_available_services(
     value_of_goods,
     pickup_contact_name=None,
     delivery_contact_name=None,
-    pickup_type=None
+    pickup_type=None,
+    customer_account=None
 ):
 
     pickup_address = get_address(pickup_address_name)
@@ -124,6 +125,34 @@ def get_letmeship_available_services(
         'pickupInterval': {'date': pickup_date},
         'contentDescription': description_of_content
     }}
+    if customer_account:
+        payload['shipmentDetails']['exworks'] = {
+            "accountNumber": customer_account,
+            "exworkType": "RECEIVER_PAYS",
+            "address": {
+                "address": {
+                    "countryCode": delivery_address.country_code,
+                    "zip": delivery_address.pincode,
+                    "city": delivery_address.city,
+                    "street": delivery_address.address_line1,
+                    "houseNo": "",
+                    "addressInfo1": delivery_address.address_line2 if 'address_line1_con' not in delivery_address else delivery_address.address_line1_con,
+                    "addressInfo2": '' if 'address_line1_con' not in delivery_address else delivery_address.address_line2,
+                    "stateCode": delivery_address.state if delivery_address.state != '' else None
+                },
+                "company": delivery_address.address_title,
+                "person": {
+                    "title": delivery_contact.title,
+                    "firstname": delivery_contact.first_name,
+                    "lastname": delivery_contact.last_name
+                },
+                "phone": {
+                    "phoneNumber": delivery_contact.phone,
+                    "phoneNumberPrefix": delivery_contact.phone_prefix.replace(" ", "") if ' ' in delivery_contact.phone_prefix else delivery_contact.phone_prefix
+                },
+                "email": delivery_contact.email
+            }
+        }
 
     try:
         available_services = []
@@ -150,6 +179,7 @@ def get_letmeship_available_services(
                 available_service.real_weight = price_info['realWeight']
                 available_service.total_price = price_info['netPrice']
                 available_service.price_info = price_info
+                available_service.exWorkType = response['supportedExWorkType']
                 available_services.append(available_service)
             return available_services
         else:
@@ -176,7 +206,8 @@ def create_letmeship_shipment(
     tracking_notific_email,
     pickup_contact_name=None,
     delivery_contact_name=None,
-    pickup_type=None
+    pickup_type=None,
+    customer_account=None
 ):
 
     pickup_address = get_address(pickup_address_name)
@@ -298,6 +329,36 @@ def create_letmeship_shipment(
                                      'emails': [shipment_notific_email]}},
         'labelEmail': True,
     }
+
+    if customer_account:
+        payload['shipmentDetails']['exworks'] = {
+            "accountNumber": customer_account,
+            "exworkType": "RECEIVER_PAYS",
+            "address": {
+                "address": {
+                    "countryCode": delivery_address.country_code,
+                    "zip": delivery_address.pincode,
+                    "city": delivery_address.city,
+                    "street": delivery_address.address_line1,
+                    "houseNo": "",
+                    "addressInfo1": delivery_address.address_line2 if 'address_line1_con' not in delivery_address else delivery_address.address_line1_con,
+                    "addressInfo2": '' if 'address_line1_con' not in delivery_address else delivery_address.address_line2,
+                    "stateCode": delivery_address.state if delivery_address.state != '' else None
+                },
+                "company": delivery_address.address_title,
+                "person": {
+                    "title": delivery_contact.title,
+                    "firstname": delivery_contact.first_name,
+                    "lastname": delivery_contact.last_name
+                },
+                "phone": {
+                    "phoneNumber": delivery_contact.phone,
+                    "phoneNumberPrefix": delivery_contact.phone_prefix.replace(" ", "") if ' ' in delivery_contact.phone_prefix else delivery_contact.phone_prefix
+                },
+                "email": delivery_contact.email
+            }
+        }
+
     try:
         response_data = requests.post(url=url,
                                       auth=(service_provider.api_key,

--- a/shipment/shipment/doctype/shipment/shipment.js
+++ b/shipment/shipment/doctype/shipment/shipment.js
@@ -593,6 +593,10 @@ frappe.ui.form.on('Shipment', {
 			if (frm.doc.pickup_date < frappe.datetime.get_today()) {
 				frappe.throw(__("Pickup Date cannot be in the past"));
 			}
+			let delivery_note
+			if (frm.doc.shipment_delivery_notes.length > 0){
+				delivery_note = frm.doc.shipment_delivery_notes[0]['delivery_note']
+			}
 			frappe.call({
 				method: "shipment.shipment.doctype.shipment.shipment.fetch_shipping_rates",
 				freeze: true,
@@ -608,7 +612,8 @@ frappe.ui.form.on('Shipment', {
 					pickup_contact_name: frm.doc.pickup_contact_name,
 					delivery_contact_name: frm.doc.delivery_contact_name,
 					value_of_goods: frm.doc.value_of_goods,
-					pickup_type: frm.doc.pickup_type
+					pickup_type: frm.doc.pickup_type,
+					delivery_note: delivery_note
 				},
 				callback: function(r) {
 					if (r.message) {


### PR DESCRIPTION
ASANA: https://app.asana.com/0/1202487840949173/1204328200215835/f

Feature Request is to add a new workflow for LetMeShip that creates a Shipment Service for "Ex Works-Zustellung" and uses the provided Customer Account value as the "Kundennummer".

Expected Behaviour:
1. The current shipment services must not change and/or break.
2. The new "Ex Works" Shipment Service should use the defined Customer Account for the "Ex Works-Zustellung" service.

Note: This must be a new and separate workflow/button under the "Fetch Shipping Rates" button.
Idea: Maybe we should make customer_account mandatory if use_customer_account is checked by the user?
Currently, the user can save the Delivery Note and submit it even if the Customer Account field is blank → I believe that this will cause errors in the payload.

What I did:
1. Added the "Exworks" in the payload if the DN "Incoterm" type is "EXW (Ex Works)"
Sample payload for getting services:
`{'pickupInfo': {'address': {'countryCode': 'DE', 'zip': '55619', 'city': 'Hennweiler', 'street': 'Am Markt 1', 'addressInfo1': None, 'houseNo': ''}, 'company': 'ESO Electronic Service Ottenbr', 'person': {'title': 'MS', 'firstname': 'Vanessa', 'lastname': 'Bualat'}, 'phone': {'phoneNumber': '9455202878', 'phoneNumberPrefix': '+63'}, 'email': 'service@eso-hygiene.com'}, 'deliveryInfo': {'address': {'countryCode': 'DK', 'zip': '2730', 'city': 'Herlev', 'street': 'Marielundvej 30, 2', 'addressInfo1': None, 'addressInfo2': '', 'houseNo': '', 'stateCode': None}, 'company': 'Atlatron APS', 'person': {'title': 'MR', 'firstname': 'Viktor', 'lastname': 'Jankovic'}, 'phone': {'phoneNumber': '61479010', 'phoneNumberPrefix': '+45'}, 'email': 'vic@atlatron.com'}, 'shipmentDetails': {'contentDescription': 'Elektronikbaugruppen / PCB Assemblies', 'shipmentType': 'PARCEL', 'shipmentSettings': {'saturdayDelivery': False, 'ddp': False, 'insurance': False, 'pickupOrder': True, 'pickupTailLift': False, 'deliveryTailLift': False, 'holidayDelivery': False}, 'goodsValue': '4501', 'parcelList': [{'height': 1, 'width': 1, 'length': 1, 'weight': 1, 'quantity': 1, 'contentDescription': 'Elektronikbaugruppen / PCB Assemblies'}], 'pickupInterval': {'date': '2023-04-17'}, 'exworks': {'accountNumber': 'V592Y5', 'exworkType': 'RECEIVER_PAYS', 'address': {'address': {'countryCode': 'DK', 'zip': '2730', 'city': 'Herlev', 'street': 'Marielundvej 30, 2', 'houseNo': '', 'addressInfo1': None, 'addressInfo2': '', 'stateCode': None}, 'company': 'Atlatron APS', 'person': {'title': 'MR', 'firstname': 'Viktor', 'lastname': 'Jankovic'}, 'phone': {'phoneNumber': '61479010', 'phoneNumberPrefix': '+45'}, 'email': 'vic@atlatron.com'}}}}`

Sample return from letmeship:
<img width="773" alt="image" src="https://user-images.githubusercontent.com/40702858/232519497-ef7631ef-b56b-4a64-96bc-cae7515dffe3.png">

Note: 
From the letmeship return there are no services that indicate "supportedExWorkType" this should be confirmed first in letmeship end if this is by default or they missed this. And also if this is the indicator for the services that offered ExWorkType of shipment.

For testing, we need a sandbox to avoid booking live data.