### PR TITLE
feat:(shipment)Implement auto-add preset function + Add pickup date validation

### DIFF
--- a/shipment/shipment/doctype/shipment/shipment.py
+++ b/shipment/shipment/doctype/shipment/shipment.py
@@ -403,3 +403,22 @@ def is_mask_shipment(delivery_note):
                                    'item_code': ['in', ('990593',
                                                         '990588')]}, 'qty')
         return {'is_mask': is_mask, 'qty': qty}
+
+@frappe.whitelist()
+def get_holidays(company = 'Newmatik GmbH', exclude_weekend = True, from_date = None, to_date = None):
+    """
+        Return list of holidays
+    """	
+    exclude_weekend = json.loads(exclude_weekend)
+    holiday_list = frappe.get_cached_value('Company', company, "default_holiday_list")
+    condition = " parent='%s'" % holiday_list
+    condition += " and holiday_date between '%s' and '%s'" % (from_date or "1900-01-01", to_date or "9999-12-31")
+    if exclude_weekend:
+        condition += "and description not in ('Sunday', 'Saturday')"
+
+
+    holidays = frappe.db.sql('''select holiday_date from `tabHoliday` where %s''' % condition, as_dict=1)
+    
+    holidays = sorted(holidays, key=lambda k:k['holiday_date'])
+
+    return holidays


### PR DESCRIPTION
ref : https://app.asana.com/0/1202488269220482/1204954883493524

Preset:
--
Requirements:
When the user fills out the preset field, it should automatically trigger the "Add Preset" button. 
![preset](https://github.com/elexess/erp-shipment/assets/85614308/bb58f91e-2766-4438-ac76-c42209769c3a)

Pickup Date:
--
The pickup_date field should not allow dates that are weekends and/or holidays.

Suggested Error Message: "The Pickup Date should not be a weekend or a holiday. Please select another date."
![pickupdate](https://github.com/elexess/erp-shipment/assets/85614308/057591bf-2f45-426f-b4ef-0fe3fc4e4f69)


