### PR TITLE
fix:(shipment.js)Add on key press enter in preset field

### DIFF
--- a/shipment/shipment/doctype/shipment/shipment.js
+++ b/shipment/shipment/doctype/shipment/shipment.js
@@ -163,10 +163,20 @@ frappe.ui.form.on('Shipment', {
             })
         }
 
-
+        // Add preset to child table on select of preset on click
         $('#awesomplete_list_6').unbind('click').bind('click', function (e) {
             set_presets(e.target.innerText)
         })
+
+        // Add preset to child table on select of preset on key press enter
+        var div = $('[data-fieldname="preset"]').closest('div');
+            div.prop('id','awesomplete_list_wrapper')
+            $('div#awesomplete_list_6').attr('tabindex', '0');
+            $('#awesomplete_list_wrapper').unbind('keydown').on('keydown', function (event) {
+                if (event.type === 'keydown' && event.which === 13){
+                    set_presets(event.target.value);
+                }
+        });
         
         if(frm.is_new()) setTimeout(function() { $('input[data-fieldname="preset"]').focus()},500);
 


### PR DESCRIPTION
ref https://app.asana.com/0/1202487840949173/1204954883493524/f

Request:
--
When the user fills out the preset field, it should automatically trigger the "Add Preset" button. 

Same function with
https://github.com/elexess/erp-shipment/pull/137/files

Added a new trigger to the dropdown to accept key selection. Before it only triggers the function via clicks in mouse.



