### PR TITLE
fix(shipment.js): show delivery_contact_name to all types

### DIFF
--- a/shipment/shipment/doctype/shipment/shipment.js
+++ b/shipment/shipment/doctype/shipment/shipment.js
@@ -267,7 +267,7 @@ frappe.ui.form.on('Shipment', {
 			frm.set_df_property("delivery_contact_name", "reqd", 0);
 			frm.set_value("delivery_customer", '');
 			frm.set_value("delivery_supplier", '');
-			frm.toggle_display("delivery_contact_name", false)
+			frm.toggle_display("delivery_contact_name", true)
 			frm.trigger('delivery_company')
 		}
 		else {


### PR DESCRIPTION
**_Reference:_** [Asana Link](https://app.asana.com/0/1202487840949173/1205161193368323/f)

**Purpose:** Show the delivery_contact_name field in all types of Delivery including **Company**

_Included screenshots and a screen record as sample reference:_
![image](https://github.com/elexess/erp-shipment/assets/58759735/7d7d0ca4-b6fc-4d42-b626-18ea256cacf2)

https://github.com/elexess/erp-shipment/assets/58759735/1a8f20b5-da16-4671-90f5-446ae15d25c8

