### PR TITLE
fix(shipment): one to many shipping cost

### DIFF
--- a/shipment/shipment/doctype/shipment/shipment.py
+++ b/shipment/shipment/doctype/shipment/shipment.py
@@ -456,7 +456,7 @@ def calculate_shipping_cost(data):
     for parcel in data['shipment_parcel']: 
         count += parcel['count']
 
-    new_rate = base_price + (x * count)
+    new_rate = ( base_price + (x * count) ) / len(data['shipment_delivery_notes'])
 
 
     value_of_goods = 0
@@ -491,7 +491,7 @@ def calculate_shipping_cost(data):
         
         # set delivery note grand_total
         dn_total = frappe.db.get_value("Delivery Note", dn['delivery_note'], 'grand_total')
-        frappe.db.set_value("Shipment Delivery Notes", {"delivery_note": dn['delivery_note']}, 'grand_total', dn_total)
+        frappe.db.set_value("Shipment Delivery Notes", {"parent": dn['parent'], "delivery_note": dn['delivery_note']}, 'grand_total', dn_total)
         
         value_of_goods += dn_total
 


### PR DESCRIPTION
**Ref:** https://github.com/elexess/erp-shipment/pull/145#issuecomment-1681588950

**Result:** 
Example: SHIPMENT-02585-1
![shipmentcost2](https://github.com/elexess/erp-shipment/assets/36461178/e40dda08-a961-4384-918b-a330e42a39a9)

_DN-DE-23-00145-1_
<img width="1290" alt="image" src="https://github.com/elexess/erp-shipment/assets/36461178/4bb4272c-8c36-4bea-acef-21a63b408ad3">

_DN-FOC-DE-23-00022-1_
<img width="1292" alt="image" src="https://github.com/elexess/erp-shipment/assets/36461178/350478de-6ffa-409a-9346-03dbdb347302">

_DN-FOC-DE-23-00021-1_
<img width="1231" alt="image" src="https://github.com/elexess/erp-shipment/assets/36461178/016a3cc6-9a28-4d99-9ce6-ab48351a4e6d">


**Calculation:** 
Margin Cost = 2.5
Base Cost = 204.45
No of Parcels = 2
No of Delivery Notes = 3

shipping cost = ( 204.45 + (2.5 * 2) ) / 3
shipping cost = **69.8167**
rounded into 2 decimal places = **69.82**
