### PR TITLE
fix(shipment): set cost to 2 decimal places

### DIFF
--- a/shipment/shipment/doctype/shipment/shipment.py
+++ b/shipment/shipment/doctype/shipment/shipment.py
@@ -18,6 +18,7 @@ from shipment.api.packlink import get_packlink_available_services, create_packli
 from shipment.api.sendcloud import get_sendcloud_available_services, create_sendcloud_shipment, get_sendcloud_label, get_sendcloud_tracking_data
 from shipment.api.utils import get_address
 from erpnext.controllers.accounts_controller import update_child_qty_rate
+from frappe.utils import flt
 
 
 class Shipment(Document):
@@ -456,7 +457,7 @@ def calculate_shipping_cost(data):
     for parcel in data['shipment_parcel']: 
         count += parcel['count']
 
-    new_rate = ( base_price + (x * count) ) / len(data['shipment_delivery_notes'])
+    new_rate = flt(( base_price + (x * count) ) / len(data['shipment_delivery_notes']), 2)
 
 
     value_of_goods = 0
@@ -495,6 +496,6 @@ def calculate_shipping_cost(data):
         
         value_of_goods += dn_total
 
-    frappe.db.set_value("Shipment", data['name'], 'value_of_goods', value_of_goods)
+    frappe.db.set_value("Shipment", data['name'], 'value_of_goods', flt(value_of_goods, 2))
 
     return 


### PR DESCRIPTION
Ref: https://github.com/elexess/erp-shipment/pull/146#issuecomment-1683732393

Result: 
![shipcost](https://github.com/elexess/erp-shipment/assets/36461178/34a95640-6750-4933-a92b-c4d23c53f670)

DN-DE-23-00145-1
<img width="1291" alt="image" src="https://github.com/elexess/erp-shipment/assets/36461178/f3bcc3eb-2cf3-4616-81f0-5d3cae45dbe2">

DN-FOC-DE-23-00022-1
<img width="1299" alt="image" src="https://github.com/elexess/erp-shipment/assets/36461178/1177c950-3999-4fe2-b078-76e4de73e59d">

DN-FOC-DE-23-00021-1
<img width="1297" alt="image" src="https://github.com/elexess/erp-shipment/assets/36461178/5f4c99fe-038e-4f6e-8c4c-efa86fe5da55">


**Calculation:**
Calculation:
Margin Cost = 5
Base Cost = 204.45
No of Parcels = 2
No of Delivery Notes = 3

shipping cost = ( 204.45 + ( 5 * 2 ) ) / 3
shipping cost = 71.48333333333333
rounded into 2 decimal places = 71.48