### PR TITLE
fix(shipment): exclude DN with CPT from cost calculation

### DIFF
--- a/shipment/shipment/doctype/shipment/shipment.py
+++ b/shipment/shipment/doctype/shipment/shipment.py
@@ -445,11 +445,18 @@ def calculate_shipping_cost(data):
     for parcel in data['shipment_parcel']: 
         count += parcel['count']
 
-    new_rate = flt(( base_price + (x * count) ) / len(data['shipment_delivery_notes']), 2)
+    non_cpt_dn = []
+    for dn in data['shipment_delivery_notes']: 
+        incoterm = frappe.db.get_value("Delivery Note", dn['delivery_note'], 'incoterm')
+        if incoterm != "CPT (Carriage Paid To)":
+            non_cpt_dn.append(dn)
+
+
+    new_rate = flt(( base_price + (x * count) ) / len(non_cpt_dn), 2)
 
 
     value_of_goods = 0
-    for dn in data['shipment_delivery_notes']: 
+    for dn in non_cpt_dn: 
         fields = ['name', "name as docname", "name", "item_code" ,"conversion_factor", "qty", "rate", "idx", "weight_kg", "weight_per_unit"]
         trans_items = frappe.db.get_list("Delivery Note Item", {"parent": dn['delivery_note']}, fields)
 


### PR DESCRIPTION
Asana: https://app.asana.com/0/1202487840949165/1205676747243458/f

Issue:
Exclude the delivery notes with "CPT (Carriage Paid To)" Incoterm from the shipment cost calculation. 

Result: 
![shippingcpt](https://github.com/elexess/erp-shipment/assets/36461178/fc397bee-f1ec-42b1-8f51-d23ed0e899c3)

Base price = 100
Count = 2
Margin Cost = 5

Formula: 
( base price + (margin cost * count )) / no of delivery notes

So, among the 2 delivery notes, 1 is a CPT. Thus, no of delivery notes is 1. 
_( 100 + (5 *2) ) / 1 = **110**_ 
