### PR TITLE
feat: shipment tracker add url field

### DIFF
--- a/shipment/shipment/doctype/shipment_service_provider/shipment_service_provider.json
+++ b/shipment/shipment/doctype/shipment_service_provider/shipment_service_provider.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "autoname": "field:shipment_provider_name",
  "creation": "2020-04-10 07:59:17.915543",
  "doctype": "DocType",
@@ -7,6 +8,7 @@
  "field_order": [
   "shipment_provider_name",
   "enabled",
+  "shipment_tracker_url",
   "customer_id",
   "api_key",
   "api_password"
@@ -40,9 +42,15 @@
    "fieldname": "enabled",
    "fieldtype": "Check",
    "label": "Enabled"
+  },
+  {
+   "fieldname": "shipment_tracker_url",
+   "fieldtype": "Data",
+   "label": "Shipment Tracker URL"
   }
  ],
- "modified": "2020-08-19 09:11:53.483372",
+ "links": [],
+ "modified": "2024-11-29 18:32:30.926452",
  "modified_by": "Administrator",
  "module": "Shipment",
  "name": "Shipment Service Provider",


### PR DESCRIPTION
**Asana Task:** [Delivery Note: Use LetMeShip /tracking endpoint instead of Bing for Send Email button](https://app.asana.com/0/1203283251047296/1208865466348711/f)

**Features:**
- Added Shipment Tracker URL in Shipment Service Provider Doctype
- Separate Shipment Tracker file for better code maintainability
- If no estimates found from Let Me Ship API, use estimated days logic

**Sample:**
<img width="1325" alt="Screenshot 2024-11-30 at 2 04 18 AM" src="https://github.com/user-attachments/assets/ca025ae3-42f8-4d1d-b440-ce9b8d142807">
