### PR TITLE
feat(calculate_shipping_cost): add Mehrfach text

### DIFF
--- a/shipment/shipment/doctype/shipment/shipment.py
+++ b/shipment/shipment/doctype/shipment/shipment.py
@@ -552,17 +552,18 @@ def calculate_shipping_cost(data):
         # "Mehrfach" note to the Shipping item description so it's visible on
         # both the Delivery Note and the resulting Sales Invoice.
         if len(non_cpt_dn) > 1:
-            mehrfach_marker = "Mehrfachlieferung"
+            MEHRFACH_SENTINEL = "<!-- mehrfach-shipping -->"
             shipping_row = frappe.db.get_value(
                 "Delivery Note Item",
                 {"parent": dn['delivery_note'], "item_code": "Shipping"},
                 ["name", "description"],
                 as_dict=True
             )
-            if shipping_row and mehrfach_marker not in (shipping_row.description or ""):
+            if shipping_row and MEHRFACH_SENTINEL not in (shipping_row.description or ""):
                 updated_desc = (shipping_row.description or "") + (
                     "<br><small><i>Automatically split shipping cost (multiple deliveries) "
                     "/ Automatisch aufgeteilte Versandkosten (Mehrfachlieferung)</i></small>"
+                    + MEHRFACH_SENTINEL
                 )
                 frappe.db.set_value("Delivery Note Item", shipping_row.name, "description", updated_desc)
 


### PR DESCRIPTION
RE: https://github.com/newmatik/erp-shipment/pull/145
Raised by Anette B. that we should indicate that the Shipping costs are "Mehrfach" if there is more than 1 split across multiple DNs.

## AI Summary

- Adds a bilingual "Mehrfach" label to the Shipping item description when shipping costs are automatically split across multiple Delivery Notes via `calculate_shipping_cost` in the Shipment app
- The label is appended after the existing Item master description (not replacing it) and reads: *"Automatically split shipping cost (multiple deliveries) / Automatisch aufgeteilte Versandkosten (Mehrfachlieferung)"*
- Includes a duplication guard so re-running the calculation (e.g. on tracking update) does not append the text again
- When there is only a single Delivery Note, the description remains untouched

## Test plan

- [ ] Create a Shipment linked to multiple non-CPT Delivery Notes, book it, and verify the Shipping item on each DN has the appended Mehrfach text
- [ ] Create a Shipment linked to a single Delivery Note and verify the Shipping item description is unchanged
- [ ] Trigger `update_tracking` on an existing multi-DN Shipment and verify the Mehrfach text is not duplicated
- [ ] Create a Sales Invoice from one of the affected Delivery Notes and verify the Mehrfach description carries over

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shipping item descriptions are now automatically annotated with a bilingual "Mehrfach" note when shipping costs are split across multiple deliveries; the system ensures the note is added only once to avoid duplicates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->