### PR TITLE
fix: auto-split long addresses for LetMeShip 35-char limit

### DIFF
--- a/shipment/api/let_me_ship.py
+++ b/shipment/api/let_me_ship.py
@@ -11,7 +11,28 @@ import json
 from datetime import datetime, timedelta
 from frappe import _
 from newmatik.newmatik.doctype.parcel_service_type.parcel_service_type import match_parcel_service_type_alias
-from shipment.api.utils import get_address, get_company_contact, get_contact, get_tracking_url
+from shipment.api.utils import (
+    get_address,
+    get_company_contact,
+    get_contact,
+    get_tracking_url,
+    fit_letmeship_address,
+    validate_letmeship_address,
+)
+
+
+def _letmeship_auto_split_enabled():
+    """Read the Shipment Service Provider's auto_split_long_street toggle.
+
+    Defaults to enabled when the field is missing (e.g. before the doctype
+    migration has been applied) so upgrades never regress behaviour.
+    """
+    value = frappe.db.get_value(
+        'Shipment Service Provider', 'Let Me Ship', 'auto_split_long_street'
+    )
+    if value is None:
+        return True
+    return bool(int(value))
 
 
 def get_letmeship_available_services(
@@ -47,14 +68,11 @@ def get_letmeship_available_services(
         delivery_address.address_title = \
             delivery_address.address_title[:30]
 
-    if len(delivery_address.address_line1) > 35:
-        counter = 35
-        while delivery_address.address_line1[counter] != " ":
-            counter -= 1
-
-        delivery_address.update(
-            {"address_line1_con": delivery_address.address_line1[counter + 1:len(delivery_address.address_line1) - 1]})
-        delivery_address.address_line1 = delivery_address.address_line1[:counter]
+    auto_split = _letmeship_auto_split_enabled()
+    fit_letmeship_address(pickup_address, auto_split=auto_split, role="pickup")
+    fit_letmeship_address(delivery_address, auto_split=auto_split, role="delivery")
+    validate_letmeship_address(pickup_address, role="pickup")
+    validate_letmeship_address(delivery_address, role="delivery")
 
     pickupOrder = False
     if pickup_type and pickup_type == "Pickup":
@@ -109,7 +127,8 @@ def get_letmeship_available_services(
             'zip': pickup_address.pincode,
             'city': pickup_address.city,
             'street': pickup_address.address_line1,
-            'addressInfo1': pickup_address.address_line2,
+            'addressInfo1': (pickup_address.address_line1_con if pickup_address.get('address_line1_con') else pickup_address.address_line2) or '',
+            'addressInfo2': (pickup_address.address_line2 if pickup_address.get('address_line1_con') else '') or '',
             'houseNo': '',
         },
         'company': pickup_address.address_title,
@@ -126,8 +145,8 @@ def get_letmeship_available_services(
             'zip': delivery_address.pincode,
             'city': delivery_address.city,
             'street': delivery_address.address_line1,
-            'addressInfo1': delivery_address.address_line2 if 'address_line1_con' not in delivery_address else delivery_address.address_line1_con,
-            "addressInfo2": '' if 'address_line1_con' not in delivery_address else delivery_address.address_line2,
+            'addressInfo1': (delivery_address.address_line1_con if delivery_address.get('address_line1_con') else delivery_address.address_line2) or '',
+            'addressInfo2': (delivery_address.address_line2 if delivery_address.get('address_line1_con') else '') or '',
             'houseNo': '',
             'stateCode': delivery_address.state if delivery_address.state != '' else None
         },
@@ -263,14 +282,11 @@ def create_letmeship_shipment(
         delivery_address.address_title = \
             delivery_address.address_title[:30]
 
-    if len(delivery_address.address_line1) > 35:
-        counter = 35
-        while delivery_address.address_line1[counter] != " ":
-            counter -= 1
-
-        delivery_address.update(
-            {"address_line1_con": delivery_address.address_line1[counter + 1:len(delivery_address.address_line1) - 1]})
-        delivery_address.address_line1 = delivery_address.address_line1[:counter]
+    auto_split = _letmeship_auto_split_enabled()
+    fit_letmeship_address(pickup_address, auto_split=auto_split, role="pickup")
+    fit_letmeship_address(delivery_address, auto_split=auto_split, role="delivery")
+    validate_letmeship_address(pickup_address, role="pickup")
+    validate_letmeship_address(delivery_address, role="delivery")
 
     pickupOrder = False
     if pickup_type and pickup_type == "Pickup":
@@ -331,7 +347,8 @@ def create_letmeship_shipment(
                 'zip': pickup_address.pincode,
                 'city': pickup_address.city,
                 'street': pickup_address.address_line1,
-                'addressInfo1': pickup_address.address_line2 or "",
+                'addressInfo1': (pickup_address.address_line1_con if pickup_address.get('address_line1_con') else pickup_address.address_line2) or '',
+                'addressInfo2': (pickup_address.address_line2 if pickup_address.get('address_line1_con') else '') or '',
                 'houseNo': '',
             },
             'company': pickup_address.address_title,
@@ -348,8 +365,8 @@ def create_letmeship_shipment(
                 'zip': delivery_address.pincode,
                 'city': delivery_address.city,
                 'street': delivery_address.address_line1,
-                'addressInfo1': (delivery_address.address_line2 if 'address_line1_con' not in delivery_address else delivery_address.address_line1_con) or "",
-                'addressInfo2': ('' if 'address_line1_con' not in delivery_address else delivery_address.address_line2) or "",
+                'addressInfo1': (delivery_address.address_line1_con if delivery_address.get('address_line1_con') else delivery_address.address_line2) or '',
+                'addressInfo2': (delivery_address.address_line2 if delivery_address.get('address_line1_con') else '') or '',
                 'houseNo': '',
                 'stateCode': delivery_address.state if delivery_address.state != '' else None
             },

--- a/shipment/api/utils.py
+++ b/shipment/api/utils.py
@@ -1,14 +1,9 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
-
-# Copyright (c) 2020, Newmatik and contributors
-# For license information, please see license.txt
-
-from __future__ import unicode_literals
 import frappe
 from frappe import _
 from frappe.utils import escape_html
 import re
+
+LETMESHIP_STREET_LIMIT = 35
 
 
 def get_address(address_name):
@@ -113,9 +108,6 @@ def get_tracking_url(carrier, tracking_number):
     return tracking_url
 
 
-LETMESHIP_STREET_LIMIT = 35
-
-
 def _split_at_word_boundary(text, limit):
     """Split text into (head, tail) where len(head) <= limit, splitting on the
     last whitespace within the first limit+1 characters. Falls back to a hard
@@ -168,6 +160,11 @@ def fit_letmeship_address(address, auto_split=True, role=""):
     original_line1 = line1
     original_line2 = line2
 
+    # Always clear any prior continuation so the payload builder never sees a
+    # stale addressInfo1/addressInfo2 if fit_letmeship_address is invoked more
+    # than once on the same dict or if the input dict was enriched elsewhere.
+    address.address_line1_con = ""
+
     if len(line1) <= LETMESHIP_STREET_LIMIT and len(line2) <= LETMESHIP_STREET_LIMIT:
         address.address_line1 = line1
         address.address_line2 = line2
@@ -197,8 +194,6 @@ def fit_letmeship_address(address, auto_split=True, role=""):
         address.address_line2 = info2
     else:
         address.address_line2 = info1
-        if "address_line1_con" in address:
-            address.address_line1_con = ""
 
     split_happened = (
         street != original_line1
@@ -206,28 +201,29 @@ def fit_letmeship_address(address, auto_split=True, role=""):
         or address.get("address_line1_con")
     )
     if split_happened:
-        audit_message = (
-            f"Address: {address.get('name') or '?'} (role={role or '?'})\n"
-            f"line1: {original_line1!r} -> {street!r}\n"
-            f"line2: {original_line2!r} -> {address.address_line2!r}\n"
-            f"address_line1_con: {address.get('address_line1_con')!r}"
-        )
+        # Audit trail: file-logger only, and scrubbed of street content.
+        # The Address name is a stable foreign key, so operators can look up
+        # the current values on demand rather than having PII copied here.
+        line1_con = address.get("address_line1_con") or ""
+        line2_final = address.address_line2 or ""
+        payload_info1 = line1_con or line2_final
+        payload_info2 = line2_final if line1_con else ""
         try:
-            frappe.log_error(
-                message=audit_message,
-                title="LetMeShip address auto-split",
+            frappe.logger("letmeship", allow_site=True).info(
+                "LetMeShip address auto-split | address=%s role=%s "
+                "street_len=%s addressInfo1_len=%s addressInfo2_len=%s "
+                "orig_line1_len=%s orig_line2_len=%s",
+                address.get("name") or "?",
+                role or "?",
+                len(street),
+                len(payload_info1),
+                len(payload_info2),
+                len(original_line1),
+                len(original_line2),
             )
         except Exception:
-            # frappe.log_error writes an Error Log DocType row, which can fail
-            # (mid-rollback, DB issues, Frappe's 140-char title limit, etc.).
-            # Fall back to the file logger so the audit trail isn't lost
-            # silently; this is a best-effort, never-raise path.
-            try:
-                frappe.logger("letmeship", allow_site=True).exception(
-                    "LetMeShip address auto-split audit: %s", audit_message
-                )
-            except Exception:
-                pass
+            # Never let best-effort audit logging break a shipment.
+            pass
 
     continuation_field = address.get("address_line1_con") or ""
     return (

--- a/shipment/api/utils.py
+++ b/shipment/api/utils.py
@@ -20,6 +20,7 @@ def get_address(address_name):
         'country',
         'state'
     ], as_dict=1)
+    address.name = address_name
     address.country_code = frappe.db.get_value('Country',
                                                address.country, 'code').upper()
     if not address.pincode or address.pincode == '':
@@ -109,3 +110,145 @@ def get_tracking_url(carrier, tracking_number):
         tracking_url = frappe.render_template(tracking_url_template,
                                               {'tracking_url': tracking_url})
     return tracking_url
+
+
+LETMESHIP_STREET_LIMIT = 35
+
+
+def _split_at_word_boundary(text, limit):
+    """Split text into (head, tail) where len(head) <= limit, splitting on the
+    last whitespace within the first limit+1 characters. Falls back to a hard
+    character split if no whitespace is available.
+    """
+    if len(text) <= limit:
+        return text, ""
+    idx = text.rfind(" ", 0, limit + 1)
+    if idx > 0:
+        head = text[:idx].rstrip()
+        tail = text[idx + 1:].strip()
+        if len(head) <= limit:
+            return head, tail
+    return text[:limit], text[limit:].strip()
+
+
+def _pack_two_slots(parts, limit):
+    """Pack a sequence of text parts (joined with ", ") into two length-limited
+    slots, splitting on word boundaries when possible.
+
+    Returns (slot1, slot2). Content that can't fit the two slots is dropped;
+    that case is then caught by validate_letmeship_address which throws a
+    user-facing, translatable error rather than silently truncating.
+    """
+    text = ", ".join(p for p in parts if p)
+    if not text:
+        return "", ""
+    slot1, rest = _split_at_word_boundary(text, limit)
+    slot2, _dropped = _split_at_word_boundary(rest, limit)
+    return slot1, slot2
+
+
+def fit_letmeship_address(address, auto_split=True, role=""):
+    """Normalize an address dict (as returned by get_address) so it fits
+    LetMeShip's 35-character street / addressInfo1 / addressInfo2 limits.
+
+    Operates on the in-memory frappe._dict only; the Address DocType is never
+    mutated. When auto_split is True, overflow from address_line1 and
+    address_line2 is repacked across the two addressInfo slots used by the
+    LetMeShip payload builder.
+
+    Returns True when the resulting address fits every limit, False otherwise
+    (in which case validate_letmeship_address is expected to raise).
+    """
+    line1 = re.sub(r"\s+", " ", (address.address_line1 or "").replace("\t", " ")).strip()
+    line2 = re.sub(r"\s+", " ", (address.address_line2 or "").replace("\t", " ")).strip()
+
+    original_line1 = line1
+    original_line2 = line2
+
+    if len(line1) <= LETMESHIP_STREET_LIMIT and len(line2) <= LETMESHIP_STREET_LIMIT:
+        address.address_line1 = line1
+        address.address_line2 = line2
+        return True
+
+    if not auto_split:
+        address.address_line1 = line1
+        address.address_line2 = line2
+        return False
+
+    street = line1
+    cont1 = ""
+    if len(street) > LETMESHIP_STREET_LIMIT:
+        street, cont1 = _split_at_word_boundary(street, LETMESHIP_STREET_LIMIT)
+
+    overflow_parts = []
+    if cont1:
+        overflow_parts.append(cont1)
+    if line2:
+        overflow_parts.append(line2)
+
+    info1, info2 = _pack_two_slots(overflow_parts, LETMESHIP_STREET_LIMIT)
+
+    address.address_line1 = street
+    if info2:
+        address.address_line1_con = info1
+        address.address_line2 = info2
+    else:
+        address.address_line2 = info1
+        if "address_line1_con" in address:
+            address.address_line1_con = ""
+
+    split_happened = (
+        street != original_line1
+        or address.address_line2 != original_line2
+        or address.get("address_line1_con")
+    )
+    if split_happened:
+        try:
+            frappe.log_error(
+                message=(
+                    f"Address: {address.get('name') or '?'} (role={role or '?'})\n"
+                    f"line1: {original_line1!r} -> {street!r}\n"
+                    f"line2: {original_line2!r} -> {address.address_line2!r}\n"
+                    f"address_line1_con: {address.get('address_line1_con')!r}"
+                ),
+                title="LetMeShip address auto-split",
+            )
+        except Exception:
+            pass
+
+    continuation_field = address.get("address_line1_con") or ""
+    return (
+        len(street) <= LETMESHIP_STREET_LIMIT
+        and len(address.address_line2 or "") <= LETMESHIP_STREET_LIMIT
+        and len(continuation_field) <= LETMESHIP_STREET_LIMIT
+    )
+
+
+def validate_letmeship_address(address, role):
+    """Raise a user-facing, translatable error if an address still exceeds
+    LetMeShip's length limits after fit_letmeship_address has run.
+
+    Expected to be a no-op for the overwhelming majority of addresses.
+    """
+    role_label = _("pickup address") if role == "pickup" else _("delivery address")
+    name = address.get("name") or ""
+    link = "<a href='/app/address/{0}'>{1}</a>".format(name, name)
+    limit = LETMESHIP_STREET_LIMIT
+
+    checks = (
+        ("address_line1", _("Address line 1"), address.get("address_line1") or ""),
+        ("address_line2", _("Address line 2"), address.get("address_line2") or ""),
+        ("address_line1_con", _("Address line 1"), address.get("address_line1_con") or ""),
+    )
+    for _key, field_label, value in checks:
+        if len(value) > limit:
+            frappe.throw(_(
+                "LetMeShip requires the {role} {field} to be at most {limit} characters "
+                "(currently {actual}). Please shorten the Address: {link}"
+            ).format(
+                role=role_label,
+                field=field_label,
+                limit=limit,
+                actual=len(value),
+                link=link,
+            ))

--- a/shipment/api/utils.py
+++ b/shipment/api/utils.py
@@ -7,6 +7,7 @@
 from __future__ import unicode_literals
 import frappe
 from frappe import _
+from frappe.utils import escape_html
 import re
 
 
@@ -203,18 +204,28 @@ def fit_letmeship_address(address, auto_split=True, role=""):
         or address.get("address_line1_con")
     )
     if split_happened:
+        audit_message = (
+            f"Address: {address.get('name') or '?'} (role={role or '?'})\n"
+            f"line1: {original_line1!r} -> {street!r}\n"
+            f"line2: {original_line2!r} -> {address.address_line2!r}\n"
+            f"address_line1_con: {address.get('address_line1_con')!r}"
+        )
         try:
             frappe.log_error(
-                message=(
-                    f"Address: {address.get('name') or '?'} (role={role or '?'})\n"
-                    f"line1: {original_line1!r} -> {street!r}\n"
-                    f"line2: {original_line2!r} -> {address.address_line2!r}\n"
-                    f"address_line1_con: {address.get('address_line1_con')!r}"
-                ),
+                message=audit_message,
                 title="LetMeShip address auto-split",
             )
         except Exception:
-            pass
+            # frappe.log_error writes an Error Log DocType row, which can fail
+            # (mid-rollback, DB issues, Frappe's 140-char title limit, etc.).
+            # Fall back to the file logger so the audit trail isn't lost
+            # silently; this is a best-effort, never-raise path.
+            try:
+                frappe.logger("letmeship", allow_site=True).exception(
+                    "LetMeShip address auto-split audit: %s", audit_message
+                )
+            except Exception:
+                pass
 
     continuation_field = address.get("address_line1_con") or ""
     return (
@@ -231,8 +242,13 @@ def validate_letmeship_address(address, role):
     Expected to be a no-op for the overwhelming majority of addresses.
     """
     role_label = _("pickup address") if role == "pickup" else _("delivery address")
+    # Escape the Address name for HTML. Frappe DocType names can contain
+    # characters like ' or & that would break the href attribute quoting and
+    # allow injection into the rendered frappe.throw dialog. Escaping once
+    # protects both the href (attribute context) and the visible anchor text.
     name = address.get("name") or ""
-    link = "<a href='/app/address/{0}'>{1}</a>".format(name, name)
+    escaped_name = escape_html(name)
+    link = "<a href='/app/address/{0}'>{1}</a>".format(escaped_name, escaped_name)
     limit = LETMESHIP_STREET_LIMIT
 
     checks = (

--- a/shipment/api/utils.py
+++ b/shipment/api/utils.py
@@ -133,18 +133,20 @@ def _split_at_word_boundary(text, limit):
 
 
 def _pack_two_slots(parts, limit):
-    """Pack a sequence of text parts (joined with ", ") into two length-limited
-    slots, splitting on word boundaries when possible.
+    """Pack a sequence of text parts (joined with ", ") into two slots.
 
-    Returns (slot1, slot2). Content that can't fit the two slots is dropped;
-    that case is then caught by validate_letmeship_address which throws a
-    user-facing, translatable error rather than silently truncating.
+    Returns (slot1, slot2) where slot1 is always <= limit characters (split on
+    the last word boundary within the first limit+1 characters, with a hard
+    character split as a last resort). slot2 holds everything that didn't fit
+    slot1 *verbatim* -- no further splitting -- so nothing is silently
+    truncated: when slot2 exceeds limit it is handed to
+    validate_letmeship_address, which throws a user-facing, translatable error
+    pointing at the oversized field.
     """
     text = ", ".join(p for p in parts if p)
     if not text:
         return "", ""
-    slot1, rest = _split_at_word_boundary(text, limit)
-    slot2, _dropped = _split_at_word_boundary(rest, limit)
+    slot1, slot2 = _split_at_word_boundary(text, limit)
     return slot1, slot2
 
 

--- a/shipment/api/utils.py
+++ b/shipment/api/utils.py
@@ -2,6 +2,7 @@ import frappe
 from frappe import _
 from frappe.utils import escape_html
 import re
+from urllib.parse import quote
 
 LETMESHIP_STREET_LIMIT = 35
 
@@ -221,9 +222,19 @@ def fit_letmeship_address(address, auto_split=True, role=""):
                 len(original_line1),
                 len(original_line2),
             )
-        except Exception:
-            # Never let best-effort audit logging break a shipment.
-            pass
+        except Exception as audit_exc:
+            # Don't let audit logging break a shipment, but surface a warning
+            # so operators aren't blind to repeated audit failures. Nested
+            # try/except preserves the never-raise contract when the logger
+            # factory itself is the thing failing (no site context, broken
+            # log path, etc.).
+            try:
+                frappe.logger("letmeship", allow_site=True).warning(
+                    "LetMeShip audit logging failed, audit skipped: %s",
+                    str(audit_exc),
+                )
+            except Exception:
+                pass
 
     continuation_field = address.get("address_line1_con") or ""
     return (
@@ -240,13 +251,15 @@ def validate_letmeship_address(address, role):
     Expected to be a no-op for the overwhelming majority of addresses.
     """
     role_label = _("pickup address") if role == "pickup" else _("delivery address")
-    # Escape the Address name for HTML. Frappe DocType names can contain
-    # characters like ' or & that would break the href attribute quoting and
-    # allow injection into the rendered frappe.throw dialog. Escaping once
-    # protects both the href (attribute context) and the visible anchor text.
+    # Address names are derived from user-supplied address_title (autoname
+    # field:address_title) and can contain characters reserved in URL paths
+    # (/, #, ?, &) as well as HTML-special characters (', ", &). URL-encode
+    # the name for the href path segment (safe="" encodes everything except
+    # unreserved chars) and HTML-escape the visible anchor text separately.
     name = address.get("name") or ""
-    escaped_name = escape_html(name)
-    link = "<a href='/app/address/{0}'>{1}</a>".format(escaped_name, escaped_name)
+    href_name = escape_html(quote(name, safe=""))
+    text_name = escape_html(name)
+    link = "<a href='/app/address/{0}'>{1}</a>".format(href_name, text_name)
     limit = LETMESHIP_STREET_LIMIT
 
     checks = (

--- a/shipment/shipment/doctype/shipment_service_provider/shipment_service_provider.json
+++ b/shipment/shipment/doctype/shipment_service_provider/shipment_service_provider.json
@@ -11,7 +11,8 @@
   "shipment_tracker_url",
   "customer_id",
   "api_key",
-  "api_password"
+  "api_password",
+  "auto_split_long_street"
  ],
  "fields": [
   {
@@ -47,10 +48,17 @@
    "fieldname": "shipment_tracker_url",
    "fieldtype": "Data",
    "label": "Shipment Tracker URL"
+  },
+  {
+   "default": "1",
+   "description": "When enabled, addresses whose first line exceeds LetMeShip's 35-character limit are automatically split across street/addressInfo1/addressInfo2. When disabled, users get a validation error so they can shorten the Address instead.",
+   "fieldname": "auto_split_long_street",
+   "fieldtype": "Check",
+   "label": "Auto-split long street addresses"
   }
  ],
  "links": [],
- "modified": "2024-11-29 18:32:30.926452",
+ "modified": "2026-04-20 05:55:00.000000",
  "modified_by": "Administrator",
  "module": "Shipment",
  "name": "Shipment Service Provider",


### PR DESCRIPTION
## Summary

- Replaces the duplicated, buggy delivery-only street truncation block in `shipment/api/let_me_ship.py` with two shared helpers in `shipment/api/utils.py`:
  - `fit_letmeship_address(address, auto_split, role)` repacks `address_line1` + `address_line2` across the three 35-char slots LetMeShip exposes (`street` / `addressInfo1` / `addressInfo2`), splitting on word boundaries and falling back to a hard split only as a last resort. Operates in-memory; the `Address` DocType is never written back.
  - `validate_letmeship_address(address, role)` throws a localized, linked error only when the result still doesn't fit (expected to be very rare after the splitter runs).
- Applies both helpers symmetrically to pickup and delivery in `get_letmeship_available_services` and `create_letmeship_shipment`. Threads `address_line1_con` into the pickup payload's `addressInfo1`/`addressInfo2` so pickup benefits from the split too (previously only delivery did).
- Adds `Shipment Service Provider.auto_split_long_street` (Check, default 1) as an ops-level kill switch. When disabled the validator runs first and users get the clear, actionable error instead of auto-split.
- Emits one `frappe.log_error(title="LetMeShip address auto-split")` per split as an audit trail.

## Why

A production audit found 569 existing addresses over LetMeShip's 35-char `address.street` limit. Users currently see the raw API error (via [PR #170](https://github.com/newmatik/erp-shipment/pull/170)) but there's no proactive prevention, so the same long address fails every time it's used. The existing splitter only ran on delivery, had a backward-loop that underflowed into negative indices on strings without whitespace, and dropped the last character of the continuation via an off-by-one. This PR fixes all four bugs and generalizes the pattern.

## Bugs fixed in the old splitter

1. Pickup address was never truncated — only delivery. Long company/warehouse streets produced the exact HTTP 400 in Error Log `14b8499a3c`.
2. `while address_line1[counter] != \" \": counter -= 1` silently wrapped into negative indexing when no space existed in the first 36 characters.
3. Off-by-one on the continuation slice dropped the final character.
4. The block was duplicated in two functions, which is why the earlier fix was never applied evenly.

## Test plan

- [x] Unit-dry-run `fit_letmeship_address` against 11 cases covering: short line1 passthrough, long line1 only, long line1 + short line2 that fits merged, long line1 + long line2 (Shen Zhen Hope shape), 40-char single token with no spaces, tab-infested row (`...Technology Co.,Ltd⇥⇥⇥⇥⇥⇥ ⇥⇥⇥⇥⇥⇥`), short line1 + long line2. Every resulting `street` / `info1` / `info2` is ≤ 35 chars.
- [x] Spot-check the 5 hardest rows from the audit (Jungheinrich 92 chars, Shenzhen In-sail 84, Hochschule München 79 + line2, Voptica 73, Shen Zhen Hope 60+79): all fit the three-slot LetMeShip payload cleanly.
- [ ] Deploy and re-run the shipment that produced Error Log `14b8499a3c` — confirm no HTTP 400.
- [ ] Switch user language to `de` and `ro` (after companion translations PR lands) and confirm the validation message is localized.
- [ ] Toggle `auto_split_long_street` off on the `Let Me Ship` provider record and confirm users get the localized, linked validation error instead.

## Rollout

1. Merge this PR first (adds the helpers and the new doctype field).
2. Run `bench migrate` so `auto_split_long_street` lands on `Shipment Service Provider`.
3. Merge the companion translations PR in `newmatik/eso-newmatik` (`fix/letmeship-address-translations`) so DE/RO strings are inserted.
4. Monitor `Error Log` entries titled "LetMeShip address auto-split" for a few days to confirm split quality on real data.

## Companion PR

German/Romanian translations for the new user-facing strings ship as a separate migration patch in the `newmatik` app — opened immediately after this one.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic splitting of long street addresses to meet LetMeShip’s 35‑character limit, controlled by a new toggle in Shipment Service Provider (enabled by default).
  * Address payloads now prefer consolidated secondary address lines when available for more consistent shipping data.

* **Bug Fixes**
  * Improved address normalization and strict validation with clear, contextual error messages and direct links to address records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->