### PR TITLE
fix(shipment): route update_child_qty_rate through newmatik override

### DIFF
--- a/shipment/shipment/doctype/shipment/shipment.py
+++ b/shipment/shipment/doctype/shipment/shipment.py
@@ -19,7 +19,9 @@ from shipment.api.let_me_ship import get_letmeship_available_services, create_le
 from shipment.api.packlink import get_packlink_available_services, create_packlink_shipment, get_packlink_label, get_packlink_tracking_data
 from shipment.api.sendcloud import get_sendcloud_available_services, create_sendcloud_shipment, get_sendcloud_label, get_sendcloud_tracking_data
 from shipment.api.utils import get_address
-from erpnext.controllers.accounts_controller import update_child_qty_rate
+# newmatik's override of update_child_qty_rate supports parent_doctype="Delivery Note";
+# erpnext's own raises UnboundLocalError (prev_date unbound) for Delivery Note.
+from newmatik.overrides.accounts_controller import update_child_qty_rate
 from frappe.utils import flt
 
 


### PR DESCRIPTION
## Summary

Post-cutover production hotfix. After the v13 de-fork cutover, fetching
shipping rates on a **submitted** Shipment (and the **"Update Tracking and
Cost"** button, which runs the same path) fails with:

```
File "apps/shipment/.../shipment.py", line 549, in calculate_shipping_cost
    update_child_qty_rate("Delivery Note", json.dumps(trans_items, ...), ...)
File "apps/erpnext/erpnext/controllers/accounts_controller.py", line 2649, in update_child_qty_rate
    prev_date == getdate(new_date) if prev_date and new_date else False
UnboundLocalError: local variable 'prev_date' referenced before assignment
```

Reported on `SHIPMENT-05074`. The LetMeShip call itself succeeds; the
failure is writing the computed Shipping rate back onto the Delivery Notes.

## Root cause

`calculate_shipping_cost` calls `update_child_qty_rate` with
`parent_doctype="Delivery Note"`. Upstream erpnext's `update_child_qty_rate`
only binds `prev_date` / `new_date` for `Sales Order` and `Purchase Order`
(accounts_controller.py:2638-2641), but then references `prev_date`
unconditionally for every existing child item (line 2649). For any existing
`Delivery Note Item`, `prev_date` is unbound -> `UnboundLocalError`.

`newmatik` ships a corrected override of `update_child_qty_rate`
(`newmatik.overrides.accounts_controller`, registered in
`hooks.override_whitelisted_methods`) that initialises `prev_date` and adds
`Delivery Note` / `Blanket Order` support. Before the de-fork,
`shipment.py`'s `from erpnext... import update_child_qty_rate` resolved to
the **forked** erpnext, which carried that fix. Against clean upstream
erpnext 13.55.2 it no longer does. `override_whitelisted_methods` only
redirects HTTP / mapper dispatch -- it does **not** redirect direct Python
imports -- so this call site was missed by the de-fork.

## Fix

Import `update_child_qty_rate` from `newmatik.overrides.accounts_controller`
instead of from erpnext. One import line. `shipment` already depends on
`newmatik` (`api/let_me_ship.py`, `api/packlink.py`), so this is no new
dependency. The override has an identical signature and is the canonical
replacement erpnext callers are meant to use.

## Verification

Reproduced on the migrate droplet (copy of production, clean upstream
erpnext 13.55.2) against a real submitted Delivery Note:

```
erpnext upstream  update_child_qty_rate("Delivery Note", ...) -> UnboundLocalError: prev_date ...
newmatik override update_child_qty_rate("Delivery Note", ...) -> completed without error
```

## Deploy

Merge to `dev`; on production fast-forward `apps/shipment` to the new `dev`
tip and `supervisorctl restart frappe-bench-web: frappe-bench-workers:` so
the `--preload` gunicorn reloads.

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal implementation for delivery note item processing during shipping cost calculations to use an alternative approach.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newmatik/erp-shipment/pull/174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->