### PR TITLE
ci: grouped Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# Grouped Dependabot: one batched PR per ecosystem per week, not one per package.
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+    groups:
+      pip:
+        applies-to: version-updates
+        patterns: ["*"]
+      pip-security:
+        applies-to: security-updates
+        patterns: ["*"]


### PR DESCRIPTION
Adds a grouped `.github/dependabot.yml` so Dependabot opens one batched PR per ecosystem per week (detected: pip), instead of one PR per package. Config-only.