### PR TITLE
sync(11e): dev -> version-16 (#176 grouped Dependabot config)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# Grouped Dependabot: one batched PR per ecosystem per week, not one per package.
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+    groups:
+      pip:
+        applies-to: version-updates
+        patterns: ["*"]
+      pip-security:
+        applies-to: security-updates
+        patterns: ["*"]


### PR DESCRIPTION
Round 4 of the dev -> version-16 branch sync. Runbook: `docs/11e-branch-sync-dev-to-version-16.md` (migrathon-docs PR #9).

shipment was the smallest gap: a single new dev commit since 11d, **#176** (grouped Dependabot config, one batched PR per ecosystem). Cherry-picked clean, no conflicts, no v16 adaptation needed.

Everything else on `dev` predates the 11d sync and is already in `version-16`.

Verified: `compileall` clean under the v16 venv; migrate exit 0; site healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EDHTQSauLJ1xeNxFLqV9ei