### PR TITLE
fix(permissions): persist stock shipment access

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,54 @@
-## Shipment
+# Shipment
 
-Shipment
+Shipment is Newmatik's Frappe app for creating carrier bookings, labels, and
+tracking updates from ERPNext shipment documents. The current integrations are
+LetMeShip, Sendcloud, and Packlink.
 
-## Setup
+## Requirements
 
-`bench get-app shipment https://github.com/elexess/erp-shipment.git
+- Frappe Framework and ERPNext v16
+- Python 3.14
+- Node.js 24 and Redis as required by the parent bench
+- The `newmatik` app, installed first
 
-#### License
+`shipment/hooks.py` declares `required_apps = ["newmatik"]`; Shipment imports
+Newmatik's Delivery Note and parcel-service extensions at module load.
+
+## Install
+
+From the bench root:
+
+```bash
+bench get-app --branch version-16 shipment \
+  git@github.com:newmatik/erp-shipment.git
+bench --site <sitename> install-app shipment
+bench --site <sitename> migrate
+```
+
+For an exact production replica, use the release SHA rather than assuming the
+tip of `version-16`. Follow
+[`docs/developer-bench-v16.md`](https://github.com/newmatik/eso-newmatik/blob/version-16/docs/developer-bench-v16.md)
+for the complete app order and parity workflow.
+
+## Configuration
+
+Create one **Shipment Service Provider** record per carrier integration and
+configure its customer ID, API key, API password, tracking URL, and enable
+state. Keep provider credentials in the site database; never add them to this
+repository or documentation.
+
+Only enable a provider on a development site when live carrier calls are
+intended. Use provider test credentials where available.
+
+## Development
+
+Run commands from the bench root:
+
+```bash
+ruff check apps/shipment/shipment/
+bench --site <sitename> run-tests --app shipment
+```
+
+## License
 
 MIT

--- a/shipment/api/let_me_ship.py
+++ b/shipment/api/let_me_ship.py
@@ -8,10 +8,10 @@
 import requests
 import frappe
 import json
-from datetime import datetime, timedelta
+from datetime import timedelta
 from math import ceil
 from frappe import _
-from frappe.utils import escape_html
+from frappe.utils import escape_html, now_datetime
 from newmatik.newmatik.doctype.parcel_service_type.parcel_service_type import match_parcel_service_type_alias
 from shipment.api.utils import (
     get_address,
@@ -105,7 +105,7 @@ def _parse_json_list(value):
 
 def _get_pickup_interval(pickup_date, requested_from, requested_to, pickup_order, now=None):
 	"""Return a valid LetMeShip pickup interval, moving expired windows to tomorrow."""
-	now = now or datetime.now()
+	now = now or now_datetime()
 	pickup_date = str(pickup_date)
 	current_date = now.strftime("%Y-%m-%d")
 	if pickup_date < current_date:
@@ -175,35 +175,12 @@ def get_letmeship_available_services(
     if pickup_type and pickup_type == "Pickup":
         pickupOrder = True
 
-    # Get current time and ensure pickup time is in the future
-    current_date = datetime.now().strftime('%Y-%m-%d')
-    current_time = datetime.now().strftime('%H:%M:%S')
-    
-    # Default pickup time window (9 AM to 5 PM)
-    time_from = "09:00:00"  # HH:mm:ss format as required by LetMeShip API
-    time_to = "17:00:00"    # HH:mm:ss format as required by LetMeShip API
-    
-    # If pickup is today and current time is after the default pickup time, use current time + 5 minutes
-    if pickup_date == current_date and current_time > time_from:
-        next_time = (datetime.now() + timedelta(minutes=5)).strftime('%H:%M:%S')
-        time_from = next_time
-    
-    # If the date is today and time has passed 17:00 (5 PM), use tomorrow's date
-    if pickup_date == current_date and current_time > "17:00:00":
-        pickup_date = (datetime.now() + timedelta(days=1)).strftime('%Y-%m-%d')
-        # Reset to default times for next day
-        time_from = "09:00:00"
-        time_to = "17:00:00"
-    
-    # Prepare pickupInterval with proper time information
-    pickup_interval = {'date': pickup_date}
-    
-    # Add time information for pickup orders
-    if pickupOrder:
-        pickup_interval.update({
-            'timeFrom': time_from,
-            'timeTo': time_to
-        })
+    pickup_interval = _get_pickup_interval(
+        pickup_date,
+        "09:00",
+        "17:00",
+        pickupOrder,
+    )
 
     parcel_list = get_parcel_list(json.loads(shipment_parcel),
                                   description_of_content)

--- a/shipment/api/let_me_ship.py
+++ b/shipment/api/let_me_ship.py
@@ -9,7 +9,9 @@ import requests
 import frappe
 import json
 from datetime import datetime, timedelta
+from math import ceil
 from frappe import _
+from frappe.utils import escape_html
 from newmatik.newmatik.doctype.parcel_service_type.parcel_service_type import match_parcel_service_type_alias
 from shipment.api.utils import (
     get_address,
@@ -61,6 +63,30 @@ def _letmeship_response_diagnostics(response):
         f"content-type={headers.get('content-type', 'n/a')} "
         f"body_len={len(body_text)}"
     )
+
+
+def _normalize_goods_value(value_of_goods):
+	"""Return the integer goods value required by LetMeShip."""
+	try:
+		return ceil(float(value_of_goods))
+	except (TypeError, ValueError):
+		frappe.throw(_("Value of goods must be a valid number."))
+
+
+def _get_letmeship_user_error(error_response):
+	"""Return a safe, useful message from a LetMeShip error response."""
+	status = error_response.get("status") or {}
+	messages = status.get("message")
+	if messages:
+		if not isinstance(messages, list):
+			messages = [messages]
+		return "<br>".join(escape_html(str(message)) for message in messages)
+	if error_response.get("errorMessage"):
+		return _(
+			"LetMeShip could not process the shipment data. Please check the addresses, "
+			"parcel dimensions, and value of goods."
+		)
+	return None
 
 
 def get_letmeship_available_services(
@@ -198,7 +224,7 @@ def get_letmeship_available_services(
             'deliveryTailLift': False,
             'holidayDelivery': False,
         },
-        'goodsValue': value_of_goods,
+        'goodsValue': _normalize_goods_value(value_of_goods),
         'parcelList': parcel_list,
         'pickupInterval': pickup_interval
     }}
@@ -218,12 +244,8 @@ def get_letmeship_available_services(
             # Try to parse error message from response
             try:
                 error_response = json.loads(response_data.text)
-                if 'status' in error_response and 'message' in error_response['status']:
-                    messages = error_response['status']['message']
-                    if isinstance(messages, list):
-                        error_detail = '<br>'.join(messages)
-                    else:
-                        error_detail = str(messages)
+                error_detail = _get_letmeship_user_error(error_response)
+                if error_detail:
                     frappe.local.response['letmeship_error'] = error_detail
             except Exception as e:
                 frappe.log_error(f"Error parsing error response: {str(e)}")

--- a/shipment/api/let_me_ship.py
+++ b/shipment/api/let_me_ship.py
@@ -9,7 +9,7 @@ import requests
 import frappe
 import json
 from datetime import timedelta
-from math import ceil
+from math import ceil, isfinite
 from frappe import _
 from frappe.utils import escape_html, now_datetime
 from newmatik.newmatik.doctype.parcel_service_type.parcel_service_type import match_parcel_service_type_alias
@@ -68,9 +68,12 @@ def _letmeship_response_diagnostics(response):
 def _normalize_goods_value(value_of_goods):
 	"""Return the integer goods value required by LetMeShip."""
 	try:
-		return ceil(float(value_of_goods))
-	except (TypeError, ValueError):
-		frappe.throw(_("Value of goods must be a valid number."))
+		numeric_value = float(value_of_goods)
+		if not isfinite(numeric_value):
+			raise ValueError
+		return ceil(numeric_value)
+	except (OverflowError, TypeError, ValueError):
+		return frappe.throw(_("Value of goods must be a valid number."))
 
 
 def _get_letmeship_user_error(error_response):

--- a/shipment/api/let_me_ship.py
+++ b/shipment/api/let_me_ship.py
@@ -89,6 +89,49 @@ def _get_letmeship_user_error(error_response):
 	return None
 
 
+def _parse_json_list(value):
+	"""Return a list from a Frappe request argument or an existing list."""
+	if not value:
+		return []
+	if isinstance(value, str):
+		try:
+			value = json.loads(value)
+		except json.JSONDecodeError:
+			value = [value]
+	if not isinstance(value, (list, tuple, set)):
+		value = [value]
+	return [item for item in value if item]
+
+
+def _get_pickup_interval(pickup_date, requested_from, requested_to, pickup_order, now=None):
+	"""Return a valid LetMeShip pickup interval, moving expired windows to tomorrow."""
+	now = now or datetime.now()
+	pickup_date = str(pickup_date)
+	current_date = now.strftime("%Y-%m-%d")
+	if pickup_date < current_date:
+		frappe.throw(_("Pickup Date cannot be in the past"))
+	interval = {"date": pickup_date}
+	if not pickup_order:
+		return interval
+
+	time_from = f"{requested_from or '09:00'}:00"
+	time_to = f"{requested_to or '17:00'}:00"
+	current_time = now.strftime("%H:%M:%S")
+	cutoff_time = min(time_to, "17:00:00")
+	if pickup_date == current_date and current_time > time_from:
+		if now.minute < 30:
+			next_time = now.replace(minute=30, second=0, microsecond=0)
+		else:
+			next_time = (now + timedelta(hours=1)).replace(minute=0, second=0, microsecond=0)
+		next_time_text = next_time.strftime("%H:%M:%S")
+		if next_time_text >= cutoff_time:
+			interval["date"] = (now + timedelta(days=1)).strftime("%Y-%m-%d")
+		else:
+			time_from = next_time_text
+	interval.update({"timeFrom": time_from, "timeTo": time_to})
+	return interval
+
+
 def get_letmeship_available_services(
     pickup_from_type,
     delivery_to_type,
@@ -342,41 +385,14 @@ def create_letmeship_shipment(
     if pickup_type and pickup_type == "Pickup":
         pickupOrder = True
 
-    # Get current time and ensure pickup time is in the future
-    current_date = datetime.now().strftime('%Y-%m-%d')
-    current_time = datetime.now().strftime('%H:%M:%S')
-    
     # Get pickup times from the Shipment document
     shipment_doc = frappe.get_doc("Shipment", shipment)
-    time_from = f"{shipment_doc.pickup_from}:00"  # Convert HH:mm to HH:mm:ss as required by LetMeShip API
-    time_to = f"{shipment_doc.pickup_to}:00"      # Convert HH:mm to HH:mm:ss as required by LetMeShip API
-    
-    # If pickup is today and current time is after the requested pickup time, use current time + 5 minutes
-    if pickup_date == current_date and current_time > time_from:
-        # Round to next 30 minute interval
-        now = datetime.now()
-        if now.minute < 30:
-            next_time = now.replace(minute=30, second=0)
-        else:
-            next_time = (now + timedelta(hours=1)).replace(minute=0, second=0)
-        time_from = next_time.strftime('%H:%M:%S')
-    
-    # If the date is today and time has passed 17:00 (5 PM), use tomorrow's date
-    if pickup_date == current_date and current_time > "17:00:00":
-        pickup_date = (datetime.now() + timedelta(days=1)).strftime('%Y-%m-%d')
-        # Reset times to original request for next day
-        time_from = f"{shipment_doc.pickup_from}:00"
-        time_to = f"{shipment_doc.pickup_to}:00"
-    
-    # Prepare pickupInterval with proper time information
-    pickup_interval = {'date': pickup_date}
-    
-    # Add time information for pickup orders
-    if pickupOrder:
-        pickup_interval.update({
-            'timeFrom': time_from,
-            'timeTo': time_to
-        })
+    pickup_interval = _get_pickup_interval(
+        pickup_date,
+        shipment_doc.pickup_from,
+        shipment_doc.pickup_to,
+        pickupOrder,
+    )
 
     parcel_list = get_parcel_list(json.loads(shipment_parcel),
                                   description_of_content)
@@ -385,6 +401,9 @@ def create_letmeship_shipment(
                                            'Let Me Ship', ['api_key', 'api_password'], as_dict=1)
     if not service_provider:
         return []
+
+    shipment_notification_emails = _parse_json_list(shipment_notific_email)
+    tracking_notification_emails = _parse_json_list(tracking_notific_email)
 
     url = 'https://api.letmeship.com/v1/shipments'
     headers = {'Content-Type': 'application/json',
@@ -452,17 +471,17 @@ def create_letmeship_shipment(
                 'deliveryTailLift': False,
                 'holidayDelivery': False,
             },
-            'goodsValue': value_of_goods,
+            'goodsValue': _normalize_goods_value(value_of_goods),
             'parcelList': parcel_list,
             'pickupInterval': pickup_interval,
         },
         'shipmentNotification': {'trackingNotification': {
             'deliveryNotification': True,
             'problemNotification': True,
-            'emails': [] if not tracking_notific_email or tracking_notific_email == '[]' else (tracking_notific_email if isinstance(tracking_notific_email, list) else [tracking_notific_email]),
+            'emails': tracking_notification_emails,
             'notificationText': '',
         }, 'recipientNotification': {'notificationText': '',
-                                     'emails': [] if not shipment_notific_email or shipment_notific_email == '[]' else (shipment_notific_email if isinstance(shipment_notific_email, list) else [shipment_notific_email])}},
+                                     'emails': shipment_notification_emails}},
         'labelEmail': True,
     }
     
@@ -482,6 +501,20 @@ def create_letmeship_shipment(
                 title="Empty response from LetMeShip API",
             )
             return {}
+
+        if not 200 <= response_data.status_code < 300:
+            try:
+                error_response = json.loads(response_data.text)
+            except json.JSONDecodeError:
+                error_response = {}
+            error_detail = _get_letmeship_user_error(error_response) or _(
+                "LetMeShip rejected the shipment request."
+            )
+            frappe.log_error(
+                message=_letmeship_response_diagnostics(response_data),
+                title="LetMeShip shipment creation failed",
+            )
+            frappe.throw(_("LetMeShip could not create the shipment: {0}").format(error_detail))
             
         try:
             response_data = json.loads(response_data.text)
@@ -548,11 +581,14 @@ def create_letmeship_shipment(
             error_msg = response_data.get('message', 'Unknown error')
             frappe.log_error(f"Error occurred while creating Shipment: {error_msg}")
             frappe.throw(_('Error occurred while creating Shipment: {0}').format(error_msg))
-            return {}
+        else:
+            frappe.throw(_("LetMeShip did not return a shipment ID."))
+    except frappe.ValidationError:
+        raise
     except Exception as exc:
         import traceback
         error_trace = traceback.format_exc()
-        frappe.log_error(f"Error in create_letmeship_shipment: {str(exc)}\nTraceback: {error_trace}\nPayload: {json.dumps(payload)}")
+        frappe.log_error(f"Error in create_letmeship_shipment: {str(exc)}\nTraceback: {error_trace}")
         frappe.msgprint(_('Error occurred while creating Shipment: {0}'
                           ).format(str(exc)), indicator='orange',
                         alert=True)

--- a/shipment/hooks.py
+++ b/shipment/hooks.py
@@ -123,9 +123,11 @@ scheduler_events = {
 # Overriding Methods
 # ------------------------------
 #
-# override_whitelisted_methods = {
-# 	"frappe.desk.doctype.event.event.get_events": "shipment.event.get_events"
-# }
+override_whitelisted_methods = {
+	"erpnext.stock.doctype.delivery_note.delivery_note.make_shipment": (
+		"shipment.shipment.doctype.shipment.shipment.make_shipment_from_delivery_note"
+	)
+}
 #
 # each overriding function accepts a `data` argument;
 # generated from the base implementation of the doctype dashboard,
@@ -137,4 +139,3 @@ scheduler_events = {
 # exempt linked doctypes from being automatically cancelled
 #
 # auto_cancel_exempted_doctypes = ["Auto Repeat"]
-

--- a/shipment/shipment/doctype/shipment/shipment.json
+++ b/shipment/shipment/doctype/shipment/shipment.json
@@ -533,6 +533,36 @@
    "share": 1,
    "submit": 1,
    "write": 1
+  },
+  {
+   "amend": 1,
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Stock Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "amend": 1,
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Stock User",
+   "share": 1,
+   "submit": 1,
+   "write": 1
   }
  ],
  "sort_field": "modified",

--- a/shipment/shipment/doctype/shipment/shipment.py
+++ b/shipment/shipment/doctype/shipment/shipment.py
@@ -45,10 +45,10 @@ class Shipment(Document):
         if len(delivery_address.address_line1) > 35:
             frappe.throw(
                 _('Maximum length of address line 1 for delivery address is 35 characters'))
-        self.status = 'Submitted'
+        self.db_set('status', 'Submitted')
 
     def on_cancel(self):
-        self.status = 'Cancelled'
+        self.db_set('status', 'Cancelled')
 
     def validate_weight(self):
         for parcel in self.shipment_parcel:
@@ -146,6 +146,28 @@ def fetch_shipping_rates(
     return shipment_prices
 
 
+def _get_delivery_note_names(delivery_notes):
+	"""Return unique Delivery Note names from request JSON, strings, or child rows."""
+	if not delivery_notes:
+		return []
+	if isinstance(delivery_notes, str):
+		try:
+			delivery_notes = json.loads(delivery_notes)
+		except json.JSONDecodeError:
+			delivery_notes = [delivery_notes]
+	names = []
+	for row in delivery_notes:
+		if isinstance(row, str):
+			name = row
+		elif isinstance(row, dict):
+			name = row.get("delivery_note")
+		else:
+			name = getattr(row, "delivery_note", None)
+		if name and name not in names:
+			names.append(name)
+	return names
+
+
 @frappe.whitelist()
 def create_shipment(
     shipment,
@@ -163,25 +185,25 @@ def create_shipment(
     pickup_type=None,
     pickup_contact_name=None,
     delivery_contact_name=None,
-    delivery_notes=[],
+    delivery_notes=None,
 ):
     """Create Shipment for the selected provider"""
+
+    shipment_doc = frappe.get_doc("Shipment", shipment)
+    shipment_doc.check_permission("write")
+    if shipment_doc.docstatus != 1:
+        frappe.throw(_("Submit the Shipment before booking it with a service provider."))
+    if shipment_doc.shipment_id:
+        frappe.throw(_("This Shipment has already been booked."))
+    delivery_note_names = _get_delivery_note_names(shipment_doc.shipment_delivery_notes)
 
     # Decode incoming JSON data
     service_info = json.loads(service_data)
     shipment_info = {}  # Initialize as empty dict instead of list
 
-    # Validate or fix the pickup_date if provided
-    if pickup_type == "Pickup" and service_info['service_provider'] == 'LetMeShip':
-        from datetime import datetime, timedelta
-        
-        # If pickup date is today and it's after 5pm, use tomorrow's date
-        current_date = datetime.now().strftime('%Y-%m-%d')
-        current_time = datetime.now().strftime('%H:%M:%S')
-        
-        if pickup_date == current_date and current_time > "17:00:00":
-            pickup_date = (datetime.now() + timedelta(days=1)).strftime('%Y-%m-%d')
-    
+    if service_info.get('service_provider') not in {'LetMeShip', 'Packlink', 'SendCloud'}:
+        frappe.throw(_("Unsupported shipment service provider."))
+
     # Process based on service provider
     if service_info['service_provider'] == 'LetMeShip':
         shipment_info = create_letmeship_shipment(
@@ -202,7 +224,7 @@ def create_shipment(
             shipment=shipment
         )
 
-    if service_info['service_provider'] == 'Packlink':
+    elif service_info['service_provider'] == 'Packlink':
         shipment_info = create_packlink_shipment(
             pickup_from_type=pickup_from_type,
             delivery_to_type=delivery_to_type,
@@ -216,7 +238,7 @@ def create_shipment(
             delivery_contact_name=delivery_contact_name,
             service_info=service_info,
         )
-    if service_info['service_provider'] == 'SendCloud':
+    elif service_info['service_provider'] == 'SendCloud':
         shipment_info = create_sendcloud_shipment(
             shipment=shipment,
             delivery_to_type=delivery_to_type,
@@ -227,28 +249,25 @@ def create_shipment(
             description_of_content=description_of_content,
             value_of_goods=value_of_goods
         )
-    if shipment_info:
-        frappe.db.set_value('Shipment', shipment, 'service_provider',
-                            shipment_info.get('service_provider'))
-        frappe.db.set_value('Shipment', shipment, 'carrier',
-                            shipment_info.get('carrier'))
-        frappe.db.set_value('Shipment', shipment, 'carrier_service',
-                            shipment_info.get('carrier_service'))
-        frappe.db.set_value('Shipment', shipment, 'shipment_id',
-                            shipment_info.get('shipment_id'))
-        frappe.db.set_value('Shipment', shipment, 'base_price',
-                            shipment_info.get('base_price'))
-        frappe.db.set_value('Shipment', shipment, 'net_price',
-                            shipment_info.get('net_price'))
-        frappe.db.set_value('Shipment', shipment, 'total_vat',
-                            shipment_info.get('total_vat'))
-        frappe.db.set_value('Shipment', shipment, 'shipment_amount',
-                            shipment_info.get('shipment_amount'))
-        frappe.db.set_value('Shipment', shipment, 'awb_number',
-                            shipment_info.get('awb_number'))
-        frappe.db.set_value('Shipment', shipment, 'status', 'Booked')
-        if delivery_notes:
-            update_delivery_note(delivery_notes=delivery_notes,
+    if shipment_info and shipment_info.get('shipment_id'):
+        frappe.db.set_value(
+            'Shipment',
+            shipment,
+            {
+                'service_provider': shipment_info.get('service_provider'),
+                'carrier': shipment_info.get('carrier'),
+                'carrier_service': shipment_info.get('carrier_service'),
+                'shipment_id': shipment_info.get('shipment_id'),
+                'base_price': shipment_info.get('base_price'),
+                'net_price': shipment_info.get('net_price'),
+                'total_vat': shipment_info.get('total_vat'),
+                'shipment_amount': shipment_info.get('shipment_amount'),
+                'awb_number': shipment_info.get('awb_number'),
+                'status': 'Booked',
+            },
+        )
+        if delivery_note_names:
+            update_delivery_note(delivery_notes=delivery_note_names,
                                  shipment_info=shipment_info)
     else:
         service_provider_name = service_info.get('service_provider', 'shipping') if service_info else 'shipping'
@@ -268,12 +287,7 @@ def update_delivery_note(delivery_notes, shipment_info=None,
         Using db_set since some services might not exist
     """
 
-    if type(delivery_notes) != str:
-        delivery_notes_ = '["'+delivery_notes[0].delivery_note+'"]'
-    else:
-        delivery_notes_ = delivery_notes
-
-    for delivery_note in json.loads(delivery_notes_):
+    for delivery_note in _get_delivery_note_names(delivery_notes):
         dl_doc = frappe.get_doc('Delivery Note', delivery_note)
 
         if shipment_info:
@@ -282,15 +296,17 @@ def update_delivery_note(delivery_notes, shipment_info=None,
                                                               ))
             dl_doc.db_set('parcel_service_type',
                           shipment_info.get('carrier_service'))
+            if shipment_info.get('awb_number'):
+                dl_doc.db_set('tracking_number', shipment_info.get('awb_number'))
         if tracking_info:
-            dl_doc.db_set('tracking_number',
-                          tracking_info.get('awb_number'))
-            dl_doc.db_set('tracking_url',
-                          tracking_info.get('tracking_url'))
-            dl_doc.db_set('tracking_status',
-                          tracking_info.get('tracking_status'))
-            dl_doc.db_set('tracking_status_info',
-                          tracking_info.get('tracking_status_info'))
+            for fieldname, key in (
+                ('tracking_number', 'awb_number'),
+                ('tracking_url', 'tracking_url'),
+                ('tracking_status', 'tracking_status'),
+                ('tracking_status_info', 'tracking_status_info'),
+            ):
+                if tracking_info.get(key) is not None:
+                    dl_doc.db_set(fieldname, tracking_info.get(key))
 
 
 def update_tracking_info():
@@ -303,17 +319,17 @@ def update_tracking_info():
         'docstatus': 1,
         'status': 'Booked',
         'shipment_id': ['!=', ''],
-        'awb_number': ['!=', ''],
-        'tracking_status': ['!=', 'Delivered'],
         'creation': ['>=', (datetime.now() - timedelta(days=365)).strftime('%Y-%m-%d')],  # Only process shipments created within the last 365 days
     })
-    try:
-        for shipment in shipments:
+    for shipment in shipments:
+        try:
             shipment_doc = frappe.get_doc('Shipment', shipment.name)
+            if shipment_doc.tracking_status == 'Delivered':
+                continue
             tracking_info = \
                 update_tracking(shipment_doc.service_provider,
                                 shipment_doc.shipment_id,
-                                shipment,
+                                shipment.name,
                                 shipment_doc.shipment_delivery_notes)
             if tracking_info:
                 shipment_doc.db_set('awb_number',
@@ -326,9 +342,11 @@ def update_tracking_info():
                 shipment_doc.db_set('tracking_status_info',
                                     tracking_info.get('tracking_status_info'
                                                       ))
-        print('Shipments updated Successfully')
-    except Exception as exc:
-        print(str(exc))
+        except Exception:
+            frappe.log_error(
+                title=f"Shipment tracking update failed: {shipment.name}",
+                message=frappe.get_traceback(),
+            )
 
 
 @frappe.whitelist()
@@ -462,26 +480,45 @@ def print_shipping_label(service_provider, shipment_id):
 
 
 @frappe.whitelist()
-def update_tracking(service_provider, shipment_id, shipment, delivery_notes=[]):
+def update_tracking(service_provider, shipment_id, shipment, delivery_notes=None):
     """ Update Tracking info in Shipment """
-    if service_provider == 'LetMeShip':
-        tracking_data = get_letmeship_tracking_data(shipment_id, shipment)
-    elif service_provider == 'Packlink':
-        tracking_data = get_packlink_tracking_data(shipment_id)
+
+    shipment_name = shipment if isinstance(shipment, str) else shipment.name
+    shipment_doc = frappe.get_doc("Shipment", shipment_name)
+    shipment_doc.check_permission("write")
+    if not shipment_doc.shipment_id:
+        frappe.throw(_("This Shipment has not been booked yet."))
+    if str(shipment_id) != str(shipment_doc.shipment_id):
+        frappe.throw(_("The Shipment ID does not match the booked Shipment."))
+    if service_provider != shipment_doc.service_provider:
+        frappe.throw(_("The service provider does not match the booked Shipment."))
+
+    delivery_note_names = _get_delivery_note_names(shipment_doc.shipment_delivery_notes)
+    if not delivery_note_names:
+        delivery_note_names = _get_delivery_note_names(delivery_notes)
+
+    if shipment_doc.service_provider == 'LetMeShip':
+        tracking_data = get_letmeship_tracking_data(shipment_doc.shipment_id, shipment_name)
+    elif shipment_doc.service_provider == 'Packlink':
+        tracking_data = get_packlink_tracking_data(shipment_doc.shipment_id)
+    elif shipment_doc.service_provider == 'SendCloud':
+        tracking_data = get_sendcloud_tracking_data(shipment_doc.shipment_id)
     else:
-        tracking_data = get_sendcloud_tracking_data(shipment_id)
+        frappe.throw(_("Unsupported shipment service provider."))
     if tracking_data:
-        if delivery_notes:
-            update_delivery_note(delivery_notes=delivery_notes,
+        if delivery_note_names:
+            update_delivery_note(delivery_notes=delivery_note_names,
                                  tracking_info=tracking_data)
-        frappe.db.set_value('Shipment', shipment, 'awb_number',
-                            tracking_data.get('awb_number'))
-        frappe.db.set_value('Shipment', shipment, 'tracking_status',
-                            tracking_data.get('tracking_status'))
-        frappe.db.set_value('Shipment', shipment, 'tracking_status_info',
-                            tracking_data.get('tracking_status_info'))
-        frappe.db.set_value('Shipment', shipment, 'tracking_url',
-                            tracking_data.get('tracking_url'))
+        frappe.db.set_value(
+            'Shipment',
+            shipment_name,
+            {
+                'awb_number': tracking_data.get('awb_number'),
+                'tracking_status': tracking_data.get('tracking_status'),
+                'tracking_status_info': tracking_data.get('tracking_status_info'),
+                'tracking_url': tracking_data.get('tracking_url'),
+            },
+        )
     
     return tracking_data
 

--- a/shipment/shipment/doctype/shipment/shipment.py
+++ b/shipment/shipment/doctype/shipment/shipment.py
@@ -345,6 +345,29 @@ def get_contact_name(ref_doctype, docname):
     return get_default_contact(ref_doctype, docname)
 
 
+def _get_delivery_note_grand_total(delivery_note):
+	"""Return the Delivery Note grand total."""
+	return frappe.db.get_value("Delivery Note", delivery_note, "grand_total")
+
+
+@frappe.whitelist()
+def make_shipment_from_delivery_note(source_name, target_doc=None):
+	"""Return a custom Shipment mapped from a submitted Delivery Note."""
+	from erpnext.stock.doctype.delivery_note.delivery_note import make_shipment as make_erpnext_shipment
+
+	shipment = make_erpnext_shipment(source_name, target_doc)
+	delivery_notes = shipment.get("shipment_delivery_notes") or []
+	if not any(row.get("delivery_note") == source_name for row in delivery_notes):
+		shipment.append(
+			"shipment_delivery_notes",
+			{
+				"delivery_note": source_name,
+				"grand_total": _get_delivery_note_grand_total(source_name),
+			},
+		)
+	return shipment
+
+
 @frappe.whitelist()
 def make_shipment(
     pickup_company,
@@ -583,4 +606,4 @@ def calculate_shipping_cost(data):
 
     frappe.db.set_value("Shipment", data['name'], 'value_of_goods', flt(value_of_goods, 2))
 
-    return 
+    return

--- a/shipment/shipment/doctype/shipment/shipment.py
+++ b/shipment/shipment/doctype/shipment/shipment.py
@@ -155,6 +155,8 @@ def _get_delivery_note_names(delivery_notes):
 			delivery_notes = json.loads(delivery_notes)
 		except json.JSONDecodeError:
 			delivery_notes = [delivery_notes]
+	if isinstance(delivery_notes, dict):
+		delivery_notes = [delivery_notes]
 	names = []
 	for row in delivery_notes:
 		if isinstance(row, str):
@@ -189,7 +191,7 @@ def create_shipment(
 ):
     """Create Shipment for the selected provider"""
 
-    shipment_doc = frappe.get_doc("Shipment", shipment)
+    shipment_doc = frappe.get_doc("Shipment", shipment, for_update=True)
     shipment_doc.check_permission("write")
     if shipment_doc.docstatus != 1:
         frappe.throw(_("Submit the Shipment before booking it with a service provider."))

--- a/shipment/shipment/doctype/shipment/test_shipment.py
+++ b/shipment/shipment/doctype/shipment/test_shipment.py
@@ -124,6 +124,17 @@ class TestShipment(unittest.TestCase):
 			{"date": "2026-08-05", "timeFrom": "10:30:00", "timeTo": "15:30:00"},
 		)
 
+	@patch("shipment.api.let_me_ship.now_datetime", return_value=datetime(2026, 8, 5, 10, 45))
+	def test_uses_frappe_system_timezone_for_pickup_window(self, system_now):
+		"""Calculate the pickup window from Frappe's configured local time."""
+		interval = _get_pickup_interval("2026-08-05", "09:00", "17:00", True)
+
+		self.assertEqual(
+			interval,
+			{"date": "2026-08-05", "timeFrom": "11:00:00", "timeTo": "17:00:00"},
+		)
+		system_now.assert_called_once_with()
+
 	def test_parses_all_delivery_note_argument_shapes(self):
 		"""Return every linked Delivery Note without duplicates."""
 		rows = [

--- a/shipment/shipment/doctype/shipment/test_shipment.py
+++ b/shipment/shipment/doctype/shipment/test_shipment.py
@@ -5,6 +5,71 @@ from __future__ import unicode_literals
 
 # import frappe
 import unittest
+from unittest.mock import patch
+
+from frappe import _dict
+
+from shipment.api.let_me_ship import _get_letmeship_user_error, _normalize_goods_value
+from shipment.shipment.doctype.shipment.shipment import make_shipment_from_delivery_note
+
+
+class FakeShipment(_dict):
+	"""Provide the child-row behavior needed by mapper unit tests."""
+
+	def append(self, fieldname, value):
+		"""Append one dictionary child row."""
+		row = _dict(value)
+		self.setdefault(fieldname, []).append(row)
+		return row
+
 
 class TestShipment(unittest.TestCase):
-	pass
+	"""Verify Shipment compatibility behavior."""
+
+	@patch(
+		"shipment.shipment.doctype.shipment.shipment._get_delivery_note_grand_total",
+		return_value=3285.97,
+	)
+	@patch("erpnext.stock.doctype.delivery_note.delivery_note.make_shipment")
+	def test_maps_delivery_note_to_legacy_child_table(self, core_mapper, get_value):
+		"""Populate the custom Delivery Note table after the ERPNext mapper runs."""
+		shipment = FakeShipment(shipment_delivery_notes=[])
+		core_mapper.return_value = shipment
+
+		result = make_shipment_from_delivery_note("DN-DE-26-00806")
+
+		self.assertIs(result, shipment)
+		self.assertEqual(len(result.shipment_delivery_notes), 1)
+		self.assertEqual(result.shipment_delivery_notes[0].delivery_note, "DN-DE-26-00806")
+		self.assertEqual(result.shipment_delivery_notes[0].grand_total, 3285.97)
+		core_mapper.assert_called_once_with("DN-DE-26-00806", None)
+		get_value.assert_called_once_with("DN-DE-26-00806")
+
+	@patch("shipment.shipment.doctype.shipment.shipment._get_delivery_note_grand_total")
+	@patch("erpnext.stock.doctype.delivery_note.delivery_note.make_shipment")
+	def test_does_not_duplicate_existing_delivery_note(self, core_mapper, get_value):
+		"""Keep an existing custom Delivery Note row unchanged."""
+		shipment = FakeShipment(
+			shipment_delivery_notes=[_dict(delivery_note="DN-DE-26-00806", grand_total=3285.97)]
+		)
+		core_mapper.return_value = shipment
+
+		result = make_shipment_from_delivery_note("DN-DE-26-00806", "target")
+
+		self.assertEqual(len(result.shipment_delivery_notes), 1)
+		core_mapper.assert_called_once_with("DN-DE-26-00806", "target")
+		get_value.assert_not_called()
+
+	def test_normalizes_goods_value_for_letmeship(self):
+		"""Round the outbound goods value up to LetMeShip's required integer."""
+		self.assertEqual(_normalize_goods_value(3285.97), 3286)
+		self.assertEqual(_normalize_goods_value("3285"), 3285)
+
+	def test_returns_safe_message_for_letmeship_parse_errors(self):
+		"""Hide provider implementation details from the user-facing error."""
+		error = _get_letmeship_user_error(
+			{"errorMessage": "Cannot deserialize value of type java.lang.Integer"}
+		)
+
+		self.assertIn("LetMeShip could not process the shipment data", error)
+		self.assertNotIn("deserialize", error)

--- a/shipment/shipment/doctype/shipment/test_shipment.py
+++ b/shipment/shipment/doctype/shipment/test_shipment.py
@@ -5,12 +5,24 @@ from __future__ import unicode_literals
 
 # import frappe
 import unittest
-from unittest.mock import patch
+from datetime import datetime
+from unittest.mock import Mock, patch
 
 from frappe import _dict
 
-from shipment.api.let_me_ship import _get_letmeship_user_error, _normalize_goods_value
-from shipment.shipment.doctype.shipment.shipment import make_shipment_from_delivery_note
+from shipment.api.let_me_ship import (
+	_get_letmeship_user_error,
+	_get_pickup_interval,
+	_normalize_goods_value,
+	_parse_json_list,
+)
+from shipment.shipment.doctype.shipment.shipment import (
+	Shipment,
+	_get_delivery_note_names,
+	make_shipment_from_delivery_note,
+	update_delivery_note,
+	update_tracking_info,
+)
 
 
 class FakeShipment(_dict):
@@ -73,3 +85,116 @@ class TestShipment(unittest.TestCase):
 
 		self.assertIn("LetMeShip could not process the shipment data", error)
 		self.assertNotIn("deserialize", error)
+
+	def test_parses_notification_email_request_arguments(self):
+		"""Decode notification recipients serialized by frappe.call."""
+		self.assertEqual(
+			_parse_json_list('["shipping@example.com", "tracking@example.com"]'),
+			["shipping@example.com", "tracking@example.com"],
+		)
+		self.assertEqual(_parse_json_list("[]"), [])
+
+	def test_moves_expired_pickup_window_to_tomorrow(self):
+		"""Avoid sending a pickup interval whose start is after its end."""
+		interval = _get_pickup_interval(
+			"2026-08-05",
+			"09:00",
+			"15:30",
+			True,
+			now=datetime(2026, 8, 5, 15, 29),
+		)
+
+		self.assertEqual(
+			interval,
+			{"date": "2026-08-06", "timeFrom": "09:00:00", "timeTo": "15:30:00"},
+		)
+
+	def test_rounds_active_pickup_window_forward(self):
+		"""Use the next half-hour while today's pickup window remains open."""
+		interval = _get_pickup_interval(
+			"2026-08-05",
+			"09:00",
+			"15:30",
+			True,
+			now=datetime(2026, 8, 5, 10, 5),
+		)
+
+		self.assertEqual(
+			interval,
+			{"date": "2026-08-05", "timeFrom": "10:30:00", "timeTo": "15:30:00"},
+		)
+
+	def test_parses_all_delivery_note_argument_shapes(self):
+		"""Return every linked Delivery Note without duplicates."""
+		rows = [
+			_dict(delivery_note="DN-1"),
+			{"delivery_note": "DN-2"},
+			_dict(delivery_note="DN-1"),
+		]
+		self.assertEqual(_get_delivery_note_names(rows), ["DN-1", "DN-2"])
+		self.assertEqual(_get_delivery_note_names('["DN-1", "DN-2"]'), ["DN-1", "DN-2"])
+
+	@patch("shipment.shipment.doctype.shipment.shipment.frappe.get_doc")
+	def test_updates_every_linked_delivery_note(self, get_doc):
+		"""Write booking and tracking details to every linked Delivery Note."""
+		delivery_notes = {"DN-1": Mock(), "DN-2": Mock()}
+		get_doc.side_effect = lambda doctype, name: delivery_notes[name]
+
+		update_delivery_note(
+			'["DN-1", "DN-2"]',
+			shipment_info={
+				"carrier": "UPS",
+				"carrier_service": "Standard Paket National",
+				"awb_number": "TRACK-123",
+			},
+			tracking_info={
+				"awb_number": "TRACK-123",
+				"tracking_url": "https://tracking.example/TRACK-123",
+				"tracking_status": "In Progress",
+				"tracking_status_info": "IN_TRANSIT",
+			},
+		)
+
+		for name, delivery_note in delivery_notes.items():
+			get_doc.assert_any_call("Delivery Note", name)
+			delivery_note.db_set.assert_any_call("delivery_type", "Parcel Service")
+			delivery_note.db_set.assert_any_call("parcel_service", "UPS")
+			delivery_note.db_set.assert_any_call(
+				"parcel_service_type", "Standard Paket National"
+			)
+			delivery_note.db_set.assert_any_call("tracking_number", "TRACK-123")
+			delivery_note.db_set.assert_any_call(
+				"tracking_url", "https://tracking.example/TRACK-123"
+			)
+			delivery_note.db_set.assert_any_call("tracking_status", "In Progress")
+			delivery_note.db_set.assert_any_call("tracking_status_info", "IN_TRANSIT")
+
+	@patch(
+		"shipment.shipment.doctype.shipment.shipment.get_address",
+		return_value=_dict(address_line1="Short street"),
+	)
+	def test_submit_and_cancel_persist_status(self, get_address):
+		"""Persist status changes made after the document database update."""
+		shipment = Mock(
+			shipment_parcel=[Mock()],
+			value_of_goods=100,
+			pickup_address_name="Pickup",
+			delivery_address_name="Delivery",
+		)
+
+		Shipment.on_submit(shipment)
+		Shipment.on_cancel(shipment)
+
+		shipment.db_set.assert_any_call("status", "Submitted")
+		shipment.db_set.assert_any_call("status", "Cancelled")
+		self.assertEqual(get_address.call_count, 2)
+
+	@patch("shipment.shipment.doctype.shipment.shipment.frappe.get_all", return_value=[])
+	def test_scheduler_retries_bookings_without_initial_tracking_data(self, get_all):
+		"""Include booked Shipments whose AWB or tracking status is still empty."""
+		update_tracking_info()
+
+		filters = get_all.call_args.kwargs["filters"]
+		self.assertNotIn("awb_number", filters)
+		self.assertNotIn("tracking_status", filters)
+		self.assertEqual(filters["status"], "Booked")

--- a/shipment/shipment/doctype/shipment/test_shipment.py
+++ b/shipment/shipment/doctype/shipment/test_shipment.py
@@ -4,11 +4,12 @@
 from __future__ import unicode_literals
 
 # import frappe
+import inspect
 import unittest
 from datetime import datetime
 from unittest.mock import Mock, patch
 
-from frappe import _dict
+from frappe import ValidationError, _dict
 
 from shipment.api.let_me_ship import (
 	_get_letmeship_user_error,
@@ -19,10 +20,18 @@ from shipment.api.let_me_ship import (
 from shipment.shipment.doctype.shipment.shipment import (
 	Shipment,
 	_get_delivery_note_names,
+	create_shipment,
 	make_shipment_from_delivery_note,
 	update_delivery_note,
 	update_tracking_info,
 )
+
+
+class OverflowingGoodsValue:
+	"""Raise the conversion overflow handled by the LetMeShip boundary."""
+
+	def __float__(self):
+		raise OverflowError
 
 
 class FakeShipment(_dict):
@@ -76,6 +85,20 @@ class TestShipment(unittest.TestCase):
 		"""Round the outbound goods value up to LetMeShip's required integer."""
 		self.assertEqual(_normalize_goods_value(3285.97), 3286)
 		self.assertEqual(_normalize_goods_value("3285"), 3285)
+
+	def test_rejects_non_finite_and_overflowing_goods_values(self):
+		"""Reject values that cannot be represented by LetMeShip's integer field."""
+		invalid_values = (
+			float("nan"),
+			float("inf"),
+			float("-inf"),
+			OverflowingGoodsValue(),
+		)
+
+		for invalid_value in invalid_values:
+			with self.subTest(value=invalid_value):
+				with self.assertRaises(ValidationError):
+					_normalize_goods_value(invalid_value)
 
 	def test_returns_safe_message_for_letmeship_parse_errors(self):
 		"""Hide provider implementation details from the user-facing error."""
@@ -144,6 +167,24 @@ class TestShipment(unittest.TestCase):
 		]
 		self.assertEqual(_get_delivery_note_names(rows), ["DN-1", "DN-2"])
 		self.assertEqual(_get_delivery_note_names('["DN-1", "DN-2"]'), ["DN-1", "DN-2"])
+
+	def test_parses_single_delivery_note_dict_as_one_row(self):
+		"""Treat one dictionary argument as one Delivery Note child row."""
+		self.assertEqual(_get_delivery_note_names({"delivery_note": "DN-1"}), ["DN-1"])
+
+	def test_locks_shipment_before_booking_checks_and_remote_call(self):
+		"""Keep the row lock and booking checks ahead of carrier side effects."""
+		source = inspect.getsource(create_shipment)
+		ordered_steps = (
+			'frappe.get_doc("Shipment", shipment, for_update=True)',
+			'shipment_doc.check_permission("write")',
+			"if shipment_doc.docstatus != 1:",
+			"if shipment_doc.shipment_id:",
+			"create_letmeship_shipment(",
+		)
+		positions = [source.index(step) for step in ordered_steps]
+
+		self.assertEqual(positions, sorted(positions))
 
 	@patch("shipment.shipment.doctype.shipment.shipment.frappe.get_doc")
 	def test_updates_every_linked_delivery_note(self, get_doc):

--- a/shipment/shipment/doctype/shipment_parcel_preset/shipment_parcel_preset.json
+++ b/shipment/shipment/doctype/shipment_parcel_preset/shipment_parcel_preset.json
@@ -90,6 +90,30 @@
    "role": "Sales Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Stock Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Stock User",
+   "share": 1,
+   "write": 1
   }
  ],
  "quick_entry": 1,

--- a/shipment/shipment/doctype/shipment_service_provider/shipment_service_provider.json
+++ b/shipment/shipment/doctype/shipment_service_provider/shipment_service_provider.json
@@ -26,7 +26,8 @@
   {
    "fieldname": "api_key",
    "fieldtype": "Data",
-   "label": "API Key"
+   "label": "API Key",
+   "permlevel": 1
   },
   {
    "fieldname": "customer_id",
@@ -36,7 +37,8 @@
   {
    "fieldname": "api_password",
    "fieldtype": "Data",
-   "label": "API Password"
+   "label": "API Password",
+   "permlevel": 1
   },
   {
    "default": "0",
@@ -92,6 +94,12 @@
    "export": 1,
    "read": 1,
    "role": "Stock User"
+  },
+  {
+   "permlevel": 1,
+   "read": 1,
+   "role": "System Manager",
+   "write": 1
   }
  ],
  "quick_entry": 1,

--- a/shipment/shipment/doctype/shipment_service_provider/shipment_service_provider.json
+++ b/shipment/shipment/doctype/shipment_service_provider/shipment_service_provider.json
@@ -75,6 +75,23 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Stock Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "export": 1,
+   "read": 1,
+   "role": "Stock User"
   }
  ],
  "quick_entry": 1,

--- a/shipment/shipment/doctype/shipment_service_provider/test_shipment_service_provider.py
+++ b/shipment/shipment/doctype/shipment_service_provider/test_shipment_service_provider.py
@@ -3,8 +3,37 @@
 # See license.txt
 from __future__ import unicode_literals
 
-# import frappe
+import json
 import unittest
+from pathlib import Path
+
+
+DOCTYPE_PATH = Path(__file__).with_name("shipment_service_provider.json")
+
 
 class TestShipmentServiceProvider(unittest.TestCase):
-	pass
+	"""Verify the Shipment Service Provider security contract."""
+
+	def setUp(self):
+		"""Load the durable DocType definition."""
+		self.doctype = json.loads(DOCTYPE_PATH.read_text())
+
+	def test_restricts_provider_credentials_to_system_managers(self):
+		"""Keep carrier credentials outside Stock User read and export access."""
+		fields = {field["fieldname"]: field for field in self.doctype["fields"]}
+
+		self.assertEqual(fields["api_key"]["permlevel"], 1)
+		self.assertEqual(fields["api_password"]["permlevel"], 1)
+
+		level_one_readers = {
+			permission["role"]
+			for permission in self.doctype["permissions"]
+			if permission.get("permlevel") == 1 and permission.get("read")
+		}
+		self.assertEqual(level_one_readers, {"System Manager"})
+		system_manager_permission = next(
+			permission
+			for permission in self.doctype["permissions"]
+			if permission.get("permlevel") == 1 and permission["role"] == "System Manager"
+		)
+		self.assertEqual(system_manager_permission.get("write"), 1)


### PR DESCRIPTION
## Summary

- persist the production Stock Manager and Stock User permissions on Shipment
- persist the production Stock Manager and Stock User permissions on Shipment Parcel Preset
- persist Stock Manager maintenance access and Stock User read/export access on Shipment Service Provider

## Context

These role permissions currently exist only as production Custom DocPerm rows. Mirroring the exact live matrices in the custom DocType JSON keeps the Shipment fork installable and prevents a future schema sync or site rebuild from losing warehouse-user access.

## Validation

- compared all three source matrices with the exact production Custom DocPerm grants
- validated all JSON documents
- verified permission roles are unique per DocType
- ruff passed
- git diff check passed

No migration or production deployment was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Access Control**
  * Expanded Stock Manager and Stock User permissions for shipments, parcel presets, and service provider records.
  * Enabled broader management, reporting, printing, exporting, sharing, and workflow actions.

* **Improvements**
  * Improved shipment creation from delivery notes, including detail mapping and duplicate prevention.
  * Enhanced pickup scheduling, notification handling, tracking updates, and delivery note synchronization.
  * Added clearer errors for failed or incomplete shipment responses.
  * Prevented unnecessary tracking refreshes for delivered shipments and improved recovery from individual failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->