### PR TITLE
feat(search): expose Shipment prefix to Awesome Bar

### DIFF
--- a/shipment/hooks.py
+++ b/shipment/hooks.py
@@ -18,6 +18,12 @@ app_license = "MIT"
 # order. See audits/E-custom-app-architecture-review.md (ADR-001).
 required_apps = ["newmatik"]
 
+# Shipment owns this document series; newmatik.api.search consumes this hook
+# without importing Shipment modules.
+awesome_bar_search_rules = [
+	{"doctype": "Shipment", "prefixes": ["SHIPMENT-"]},
+]
+
 # Includes in <head>
 # ------------------
 

--- a/shipment/test_search_hooks.py
+++ b/shipment/test_search_hooks.py
@@ -1,0 +1,20 @@
+"""Guard Shipment's fast document-search declaration."""
+
+import unittest
+
+from shipment import hooks
+
+
+class TestSearchHooks(unittest.TestCase):
+	"""Verify that the Shipment prefix remains discoverable."""
+
+	def test_declares_shipment_prefix(self):
+		"""Keep the Shipment series in the distributed search-rule hook."""
+		self.assertEqual(
+			hooks.awesome_bar_search_rules,
+			[{"doctype": "Shipment", "prefixes": ["SHIPMENT-"]}],
+		)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/shipment/test_search_hooks.py
+++ b/shipment/test_search_hooks.py
@@ -10,9 +10,9 @@ class TestSearchHooks(unittest.TestCase):
 
 	def test_declares_shipment_prefix(self):
 		"""Keep the Shipment series in the distributed search-rule hook."""
-		self.assertEqual(
+		self.assertIn(
+			{"doctype": "Shipment", "prefixes": ["SHIPMENT-"]},
 			hooks.awesome_bar_search_rules,
-			[{"doctype": "Shipment", "prefixes": ["SHIPMENT-"]}],
 		)
 
 


### PR DESCRIPTION
## Summary
- declare `SHIPMENT-` as the Shipment-owned fast-search prefix
- keep app ownership distributed without importing Shipment from Newmatik
- guard the declaration with a lightweight contract test

Related core search change: https://github.com/newmatik/eso-newmatik/pull/7194

## Test plan
- [x] `bench --site erp.localhost run-tests --app shipment --skip-before-tests --test-category all --module shipment.test_search_hooks`
- [x] `uvx --from ruff==0.15.21 ruff check .`
- [x] verify full and partial Shipment IDs against local data