### PR TITLE
fix(shipment): render persisted HTML fields

### DIFF
--- a/shipment/api/sendcloud.py
+++ b/shipment/api/sendcloud.py
@@ -6,7 +6,13 @@ import frappe
 import json
 import requests
 from frappe import _
-from shipment.api.utils import get_address, get_contact, get_company_contact, get_tracking_url
+from shipment.api.utils import (
+    format_tracking_url,
+    get_address,
+    get_company_contact,
+    get_contact,
+    get_tracking_url,
+)
 
 def total_parcel_price(parcel_price, shipment_parcel):
     count = 0
@@ -136,9 +142,9 @@ def get_sendcloud_tracking_data(shipment_id):
             tracking_data_response = \
                 requests.get('https://panel.sendcloud.sc/api/v2/parcels/{id}'.format(id=ship_id), auth=(api_key, api_password))
             tracking_data = json.loads(tracking_data_response.text)
-            tracking_url_template = \
-                '<a href="{{ tracking_url }}" target="_blank"><b>{{ _("Click here to Track Shipment") }}</b></a><br>'
-            tracking_url += frappe.render_template(tracking_url_template, {'tracking_url': tracking_data['parcel']['tracking_url']})
+            safe_tracking_url = format_tracking_url(tracking_data['parcel']['tracking_url'])
+            if safe_tracking_url:
+                tracking_url += safe_tracking_url + '<br>'
             awb_number.append(tracking_data['parcel']['tracking_number'])
             tracking_status.append(tracking_data['parcel']['status']['message'])
             tracking_status_info.append(tracking_data['parcel']['status']['message'])

--- a/shipment/api/sendcloud.py
+++ b/shipment/api/sendcloud.py
@@ -11,7 +11,6 @@ from shipment.api.utils import (
     get_address,
     get_company_contact,
     get_contact,
-    get_tracking_url,
 )
 
 def total_parcel_price(parcel_price, shipment_parcel):

--- a/shipment/api/utils.py
+++ b/shipment/api/utils.py
@@ -2,7 +2,7 @@ import frappe
 from frappe import _
 from frappe.utils import escape_html
 import re
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 LETMESHIP_STREET_LIMIT = 35
 
@@ -93,6 +93,21 @@ def get_company_contact():
     return contact
 
 
+def format_tracking_url(tracking_url):
+    """Return a safe external tracking link or an empty string."""
+    tracking_url = str(tracking_url or "").strip()
+    parsed_url = urlparse(tracking_url)
+    if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:
+        return ""
+
+    return (
+        '<a href="{0}" target="_blank" rel="noopener noreferrer"><b>{1}</b></a>'
+    ).format(
+        escape_html(tracking_url),
+        escape_html(_("Click here to Track Shipment")),
+    )
+
+
 def get_tracking_url(carrier, tracking_number):
     """ Return the formatted Tracking URL"""
 
@@ -102,11 +117,7 @@ def get_tracking_url(carrier, tracking_number):
     if url_reference:
         tracking_url = frappe.render_template(url_reference,
                                               {'tracking_number': tracking_number})
-        tracking_url_template = \
-            '<a href="{{ tracking_url }}" target="_blank"><b>{{ _("Click here to Track Shipment") }}</a></b>'
-        tracking_url = frappe.render_template(tracking_url_template,
-                                              {'tracking_url': tracking_url})
-    return tracking_url
+    return format_tracking_url(tracking_url)
 
 
 def _split_at_word_boundary(text, limit):

--- a/shipment/shipment/doctype/shipment/shipment.json
+++ b/shipment/shipment/doctype/shipment/shipment.json
@@ -154,13 +154,13 @@
   },
   {
    "fieldname": "delivery_address",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "read_only": 1
   },
   {
    "depends_on": "eval:doc.delivery_contact_name",
    "fieldname": "delivery_contact",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "read_only": 1
   },
   {
@@ -337,12 +337,12 @@
   },
   {
    "fieldname": "pickup_address",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "read_only": 1
   },
   {
    "fieldname": "pickup_contact",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "read_only": 1
   },
   {
@@ -452,7 +452,7 @@
   {
    "allow_on_submit": 1,
    "fieldname": "tracking_url",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Tracking URL",
    "read_only": 1
   },

--- a/shipment/shipment/doctype/shipment/shipment.py
+++ b/shipment/shipment/doctype/shipment/shipment.py
@@ -14,7 +14,7 @@ from frappe.model.document import Document
 from erpnext.accounts.party import get_party_shipping_address
 from frappe.contacts.doctype.contact.contact import get_default_contact
 from frappe.contacts.doctype.address.address import get_address_display
-from frappe.utils import today
+from frappe.utils import escape_html, flt, today
 from shipment.api.let_me_ship import get_letmeship_available_services, create_letmeship_shipment, get_letmeship_label, get_letmeship_tracking_data
 from shipment.api.packlink import get_packlink_available_services, create_packlink_shipment, get_packlink_label, get_packlink_tracking_data
 from shipment.api.sendcloud import get_sendcloud_available_services, create_sendcloud_shipment, get_sendcloud_label, get_sendcloud_tracking_data
@@ -22,7 +22,6 @@ from shipment.api.utils import get_address
 # newmatik's override of update_child_qty_rate supports parent_doctype="Delivery Note";
 # erpnext's own raises UnboundLocalError (prev_date unbound) for Delivery Note.
 from newmatik.overrides.accounts_controller import update_child_qty_rate
-from frappe.utils import flt
 
 
 class Shipment(Document):
@@ -388,6 +387,11 @@ def make_shipment_from_delivery_note(source_name, target_doc=None):
 	return shipment
 
 
+def _format_contact_display(*values):
+    """Join escaped contact values with trusted line-break markup."""
+    return "<br>".join(escape_html(str(value)) for value in values if value)
+
+
 @frappe.whitelist()
 def make_shipment(
     pickup_company,
@@ -413,10 +417,15 @@ def make_shipment(
 								Please set Last Name, Email and Phone for the contact <a href='#Form/Contact/{0}'>{1}</a>"
                        ).format(delivery_contact_name,
                                 delivery_contact_name))
-    delivery_contact = delivery_contact_info.first_name \
-        + delivery_contact_info.last_name + '<br>' \
-        + delivery_contact_info.email_id + '<br>' \
-        + delivery_contact_info.phone or delivery_contact_info.mobile_no
+    delivery_contact = _format_contact_display(
+        "".join(
+            part
+            for part in (delivery_contact_info.first_name, delivery_contact_info.last_name)
+            if part
+        ),
+        delivery_contact_info.email_id,
+        delivery_contact_info.phone or delivery_contact_info.mobile_no,
+    )
 
     pickup_contact_info = frappe.db.get_value('User',
                                               frappe.session.user, ['full_name', 'email', 'phone',
@@ -430,9 +439,11 @@ def make_shipment(
         frappe.throw(_("Email and Phone/Mobile of the User are mandatory to continue. </br> \
 								Please set Email/Phone for the user <a href='#Form/User/{0}'>{1}</a>"
                        ).format(frappe.session.user, frappe.session.user))
-    pickup_contact = pickup_contact_info.full_name + '<br>' \
-        + pickup_contact_info.email + '<br>' \
-        + pickup_contact_info.phone or pickup_contact_info.mobile_no
+    pickup_contact = _format_contact_display(
+        pickup_contact_info.full_name,
+        pickup_contact_info.email,
+        pickup_contact_info.phone or pickup_contact_info.mobile_no,
+    )
     shipment = frappe.new_doc('Shipment')
     shipment.pickup_company = pickup_company
     shipment.delivery_customer = delivery_customer

--- a/shipment/shipment/doctype/shipment/test_shipment.py
+++ b/shipment/shipment/doctype/shipment/test_shipment.py
@@ -19,8 +19,10 @@ from shipment.api.let_me_ship import (
 	_normalize_goods_value,
 	_parse_json_list,
 )
+from shipment.api.utils import format_tracking_url
 from shipment.shipment.doctype.shipment.shipment import (
 	Shipment,
+	_format_contact_display,
 	_get_delivery_note_names,
 	create_shipment,
 	make_shipment_from_delivery_note,
@@ -63,8 +65,32 @@ class TestShipment(unittest.TestCase):
 			"tracking_url",
 		):
 			with self.subTest(fieldname=fieldname):
+				self.assertIn(fieldname, fields)
 				self.assertEqual(fields[fieldname]["fieldtype"], "Text Editor")
 				self.assertEqual(fields[fieldname]["read_only"], 1)
+
+	def test_escapes_contact_values_before_rendering_markup(self):
+		"""Prevent stored contact data from injecting markup."""
+		value = _format_contact_display(
+			'<img src=x onerror="alert(1)">',
+			"service&tracking@example.com",
+		)
+
+		self.assertNotIn("<img", value)
+		self.assertIn("&lt;img", value)
+		self.assertIn("service&amp;tracking@example.com", value)
+		self.assertEqual(value.count("<br>"), 1)
+
+	def test_tracking_links_allow_only_escaped_http_urls(self):
+		"""Reject unsafe schemes and escape provider-controlled URLs."""
+		anchor = format_tracking_url(
+			'https://tracking.example/parcel?value="><script>alert(1)</script>',
+		)
+
+		self.assertIn('href="https://tracking.example/', anchor)
+		self.assertNotIn("<script>", anchor)
+		self.assertIn("&lt;script&gt;", anchor)
+		self.assertEqual(format_tracking_url("javascript:alert(1)"), "")
 
 	@patch(
 		"shipment.shipment.doctype.shipment.shipment._get_delivery_note_grand_total",

--- a/shipment/shipment/doctype/shipment/test_shipment.py
+++ b/shipment/shipment/doctype/shipment/test_shipment.py
@@ -5,8 +5,10 @@ from __future__ import unicode_literals
 
 # import frappe
 import inspect
+import json
 import unittest
 from datetime import datetime
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 from frappe import ValidationError, _dict
@@ -46,6 +48,23 @@ class FakeShipment(_dict):
 
 class TestShipment(unittest.TestCase):
 	"""Verify Shipment compatibility behavior."""
+
+	def test_html_display_fields_use_text_editor_controls(self):
+		"""Render persisted address, contact, and tracking markup as HTML."""
+		schema_path = Path(__file__).with_name("shipment.json")
+		schema = json.loads(schema_path.read_text(encoding="utf-8"))
+		fields = {field["fieldname"]: field for field in schema["fields"]}
+
+		for fieldname in (
+			"pickup_address",
+			"pickup_contact",
+			"delivery_address",
+			"delivery_contact",
+			"tracking_url",
+		):
+			with self.subTest(fieldname=fieldname):
+				self.assertEqual(fields[fieldname]["fieldtype"], "Text Editor")
+				self.assertEqual(fields[fieldname]["read_only"], 1)
 
 	@patch(
 		"shipment.shipment.doctype.shipment.shipment._get_delivery_note_grand_total",


### PR DESCRIPTION
## Summary
- render persisted pickup and delivery addresses and contacts as rich text
- restore clickable tracking links after plain-text fields began escaping markup
- guard the five HTML-bearing fields with a schema regression test

## Test plan
- [x] `bench --site erp.localhost run-tests --app shipment --module shipment.shipment.doctype.shipment.test_shipment` (16 tests)
- [x] `ruff check shipment/`